### PR TITLE
docs: add founding cohort validation plan

### DIFF
--- a/docs/founding-cohort-plan.md
+++ b/docs/founding-cohort-plan.md
@@ -1,0 +1,304 @@
+# Founding cohort recruitment and validation plan
+
+- **Status:** Draft
+- **Last updated:** July 23, 2026
+- **Product owner:** Kevin Tulloch
+- **Related issue:** [#35](https://github.com/tulloch022/marathoner/issues/35)
+- **Related milestone:** [Mobile External Beta](https://github.com/tulloch022/marathoner/milestone/2)
+
+## Purpose
+
+This document describes a potential approach for finding Marathoner's first
+external participants and learning whether the product creates meaningful
+value for them.
+
+It is a working hypothesis rather than a committed marketing plan. GitHub
+issues and milestones define scheduled work. Recruitment channels, targets,
+and timing should change when participant evidence shows that a different
+approach would be more responsible or effective.
+
+## Objective
+
+Recruit a deliberately small founding cohort of first-time marathoners, support
+them closely, and determine whether Marathoner helps them understand their
+training and feel prepared and in control.
+
+The first objective is learning, not download volume or revenue. A small group
+that uses the product for several weeks and provides honest feedback is more
+valuable than a large number of unqualified registrations.
+
+## Founding participant
+
+The initial participant is expected to be an English-speaking adult in the
+United States who:
+
+- is preparing for a first marathon within approximately six to twelve months;
+- is a beginner, returning runner, or runner without marathon experience;
+- wants structured guidance rather than only an activity tracker;
+- is willing to log training and complete brief check-ins;
+- is willing to discuss confusing, unhelpful, or missing parts of the product;
+  and
+- understands that the beta is not medical care or a substitute for an
+  individual professional coach.
+
+The cohort should include different starting mileage, schedules, and levels of
+running experience. It does not need to represent every future Marathoner user
+in the first test.
+
+## Participant offer
+
+The initial invitation can be summarized as:
+
+> Marathoner is being built for people preparing for their first marathon. We
+> are looking for a small group of founding participants who want a structured,
+> understandable training journey. Participation is free during the beta. In
+> return, we ask for honest feedback, regular training logs, and a short weekly
+> check-in.
+
+The offer must describe the product's actual readiness. It must not promise a
+race result, injury prevention, individualized medical advice, or features that
+have not been tested.
+
+## Readiness before recruitment
+
+Participant invitations should not begin until the team can:
+
+- explain exactly what the beta includes and excludes;
+- provide a usable mobile experience for the supported beta platforms;
+- complete onboarding, plan acceptance, activity logging, and feedback flows;
+- support account and data deletion requests;
+- collect consent for the information required by the beta;
+- respond to participant questions and product failures;
+- provide reviewed escalation guidance for pain or unusual discomfort; and
+- explain how feedback and training data will be used.
+
+Qualified experts must review production training rules and safety guidance
+before external participants are asked to rely on them.
+
+## Recruitment sequence
+
+Channels should be tested in this order. Each stage should teach the team what
+language, concerns, and product promises resonate before a broader stage
+begins.
+
+### 1. Personal network and introductions
+
+Start with runners, friends, colleagues, and people who know potential
+first-time marathoners. Ask for a direct introduction rather than a general
+social-media share.
+
+A useful question is:
+
+> Who do you know who has talked about running a marathon but does not know how
+> to begin?
+
+This channel should produce the earliest conversations because trust already
+exists and feedback can be candid.
+
+### 2. Local clubs and beginner programs
+
+Participate in local running communities before asking to recruit from them.
+Contact organizers directly and position Marathoner as a supplemental beta
+tool, not a replacement for their coaches or community.
+
+Potential collaboration includes:
+
+- inviting a few beginner members into the cohort;
+- presenting a free first-marathon planning session;
+- collecting feedback from organizers about beginner confusion; and
+- supporting a small group preparing for the same race.
+
+### 3. Independent running stores
+
+Running stores regularly meet customers buying their first proper shoes or
+preparing for an unfamiliar distance. An in-person conversation may lead to:
+
+- introductions to beginner training groups;
+- a small QR-code card for the cohort waitlist;
+- an educational first-marathon session; or
+- expert feedback about shoe education and replacement guidance.
+
+Marathoner should provide useful education and should not imply that a store
+endorses unreviewed training guidance.
+
+### 4. Race organizers
+
+Begin with smaller races where a direct relationship is practical. Possible
+offers include a beginner readiness checklist, an educational webinar, or a
+limited number of beta invitations that the organizer distributes.
+
+Organizers should communicate with their registrants. Marathoner should not ask
+for participant contact lists or receive registration data without an explicit,
+appropriate agreement and participant consent.
+
+### 5. Online running communities
+
+Relevant spaces may include first-marathon and beginner-running communities on
+Reddit, Facebook, Discord, and race-specific group chats.
+
+The team should contribute useful information, follow each community's rules,
+and obtain moderator permission before recruiting. The message should invite
+people to shape a focused first-marathon system rather than ask for anonymous
+app downloads.
+
+### 6. Founder-led content
+
+Public content should use the founder's real training experience to answer
+specific beginner questions. Potential topics include:
+
+- what happens before a conventional marathon plan begins;
+- why an easy run may feel too hard;
+- how Couch to 5K, base building, and marathon training fit together;
+- what first-time marathoners should understand about shoes and mileage;
+- how fueling, hydration, pacing, and sleep affect preparation; and
+- how a plan should respond when training no longer matches the schedule.
+
+Each useful piece can point to one founding-cohort waitlist. Content should
+teach first and recruit second.
+
+### 7. Marathoner Strava club
+
+A Marathoner Strava club may provide cohort events, updates, and encouragement
+without adding a social feed to the product. It should complement the private,
+focused Marathoner experience rather than become a prerequisite for using it.
+
+### 8. Participant referrals
+
+After a participant has received meaningful value for approximately two weeks,
+ask whether they know one other first-time marathoner who may benefit. A simple
+personal invitation is enough for the first cohort. A complex referral system
+is unnecessary.
+
+### 9. Small paid experiments
+
+Paid acquisition should begin only after organic participants demonstrate that
+they can complete onboarding, understand the plan, and remain engaged.
+
+Early experiments should test a specific message with a small budget and a
+defined learning question. Broad app-install campaigns should not substitute
+for evidence that the experience works.
+
+## Initial funnel hypothesis
+
+The first recruitment funnel is a planning target, not an industry benchmark:
+
+| Stage | Initial target |
+| --- | ---: |
+| Potential participants or trusted connectors identified | 100 |
+| Genuine conversations | 40 |
+| People accepting a beta invitation | 25 |
+| Participants completing onboarding | 18 |
+| Participants active after four weeks | 12 |
+| Participants active after eight weeks | 8 |
+
+Large differences from these numbers are evidence. For example, high interest
+with poor onboarding indicates a product or expectation problem, while few
+conversations from many introductions may indicate weak positioning.
+
+## Validation signals
+
+### Activation
+
+A participant is activated when they:
+
+1. complete onboarding;
+2. understand and accept the initial plan;
+3. identify the next scheduled workout; and
+4. log a first activity or required check-in.
+
+### Four-week use
+
+A four-week active participant has used Marathoner during at least three of the
+first four weeks and can explain what they are doing next and why.
+
+The first review should examine:
+
+- where onboarding was abandoned;
+- whether the plan was understood and trusted;
+- whether logging became part of the participant's routine;
+- which guidance changed a decision or behavior;
+- whether the participant felt more prepared and in control; and
+- which confusing or unsafe behaviors require correction.
+
+### Eight-week use
+
+An eight-week active participant has used Marathoner during at least six of the
+first eight weeks and still considers it useful to their preparation.
+
+The second review should examine:
+
+- whether the plan remained realistic as life and training changed;
+- whether adjustments were understood and approved;
+- whether effort, shoe, sleep, fueling, hydration, and pacing guidance arrived
+  at useful times;
+- whether participants would recommend the experience to another first-time
+  marathoner; and
+- why participants reduced or stopped using the product.
+
+### Safety and trust
+
+Acquisition should pause when a critical training recommendation, safety
+escalation, privacy, or data-integrity failure remains unresolved. Growth is not
+evidence of success when participants cannot safely understand or rely on the
+product.
+
+## Decision gates
+
+After the four-week and eight-week reviews, choose one of three paths:
+
+- **Proceed:** Participants activate, return, understand the guidance, and
+  report increasing preparedness. Recruit a slightly larger cohort or test the
+  next channel.
+- **Refine:** People want the outcome but onboarding, comprehension, or ongoing
+  use is weak. Correct the experience and repeat a small cohort.
+- **Pause:** Trust, safety, product value, or support capacity is inadequate.
+  Stop recruitment until the underlying problem is resolved.
+
+The team should not increase paid acquisition merely to compensate for weak
+activation or retention.
+
+## Activities to defer
+
+Until the initial cohort produces dependable evidence, avoid:
+
+- broad Instagram, TikTok, or app-install campaigns;
+- paid influencer sponsorships;
+- expensive race-expo booths;
+- large public launch announcements;
+- complex referral rewards; and
+- purchasing large, low-intent email or waitlist audiences.
+
+## Public and private information
+
+The public repository may contain:
+
+- this strategy and its revisions;
+- aggregate funnel counts;
+- anonymized themes and product learnings;
+- public recruitment materials; and
+- decisions produced from cohort evidence.
+
+The public repository must not contain:
+
+- participant names, email addresses, phone numbers, or account identifiers;
+- individual health or training records;
+- private interview notes or recordings;
+- credentials, consent records, or access tokens;
+- private partner conversations or contracts; or
+- sensitive budgets and acquisition-account information.
+
+Participant operations require a private system with appropriate access,
+retention, consent, and deletion practices. Anonymization means removing enough
+context that a person cannot reasonably be identified, not merely deleting
+their name.
+
+## Open questions
+
+- What is the responsible maximum size for the first supported cohort?
+- Which qualified experts will review the training rules and safety guidance?
+- Which beta platforms will participants be required to use?
+- What private tool will manage outreach, consent, and interview notes?
+- Which local clubs, stores, and races are appropriate first partners?
+- What evidence should permit the first paid acquisition experiment?
+- How should participation end when a runner graduates, withdraws, or changes
+  their marathon goal?

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -378,6 +378,10 @@ applications, or integrations.
 The target is a small cohort of English-speaking adults in the United States
 preparing for their first marathon later in 2027.
 
+The proposed recruitment sequence, participant offer, and early learning gates
+are described in the
+[founding cohort recruitment and validation plan](founding-cohort-plan.md).
+
 The beta is a responsive web experience. It does not promise native apps,
 Garmin integration, advanced analytics, or broad public availability.
 


### PR DESCRIPTION
## Summary

- add a public draft plan for recruiting and validating Marathoner's founding cohort
- define the target participant, recruitment sequence, initial funnel hypothesis, and four-week and eight-week learning gates
- document safety stop conditions and the boundary between public learnings and private participant information
- link the plan from the existing product vision

## Linked issue

Closes #35

## Verification

- [x] `git diff --cached --check`
- [x] Reviewed every changed line
- [ ] `npm run lint` (not run because this changes Markdown only)
- [ ] `npm run build` (not run because this changes Markdown only)

## Notes

The funnel numbers are starting hypotheses, not promised outcomes or industry benchmarks. Individual outreach records, participant data, interview notes, and partner conversations remain outside the public repository.
