### PR TITLE
fix: render sections as semantic responsive panels

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,8 @@ import App from './App'
 vi.mock('framer-motion', () => ({
   motion: {
     button: 'button',
-    div: 'div'
+    div: 'div',
+    section: 'section'
   }
 }))
 
@@ -37,6 +38,9 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Plan' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Track' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Analyze' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('navigation', { name: 'Training sections' })
+    ).toBeInTheDocument()
   })
 
   it.each(sectionTransitions)(
@@ -45,16 +49,27 @@ describe('App', () => {
       const user = userEvent.setup()
       render(<App />)
 
-      await user.click(screen.getByRole('button', { name: sectionName }))
+      const sectionTrigger = screen.getByRole('button', { name: sectionName })
+      await user.click(sectionTrigger)
 
       expect(
         screen.getByRole('heading', { level: 1, name: sectionHeading })
       ).toBeInTheDocument()
       expect(
+        screen.getByRole('region', { name: sectionHeading })
+      ).toBeInTheDocument()
+      expect(
         screen.queryByRole('heading', { level: 1, name: 'Marathoner.' })
       ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('navigation', { name: 'Training sections' })
+      ).not.toBeInTheDocument()
 
-      await user.click(screen.getByRole('button', { name: 'X' }))
+      const closeButton = screen.getByRole('button', {
+        name: `Close ${sectionHeading} panel`
+      })
+      expect(closeButton).toHaveFocus()
+      await user.click(closeButton)
 
       expect(
         screen.getByRole('heading', { level: 1, name: 'Marathoner.' })
@@ -62,6 +77,39 @@ describe('App', () => {
       expect(
         screen.queryByRole('heading', { level: 1, name: sectionHeading })
       ).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: sectionName })).toHaveFocus()
     }
   )
+
+  it('opens and closes a section with the keyboard', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    const planTrigger = screen.getByRole('button', { name: 'Plan' })
+    planTrigger.focus()
+
+    await user.keyboard('{Enter}')
+
+    expect(
+      screen.getByRole('region', { name: 'Plan Your Workouts' })
+    ).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('region')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Plan' })).toHaveFocus()
+  })
+
+  it('keeps panel controls outside the section trigger buttons', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: 'Track' }))
+
+    expect(
+      document.querySelector(
+        'button button, button input, button select, button textarea, button a[href]'
+      )
+    ).toBeNull()
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import LoginButton from "./components/LoginButton";
 import Title from "./components/Title";
@@ -8,18 +8,48 @@ import SignUpButton from "./components/SignUpButton";
 import ShoeTracker from "./components/ShoeTracker";
 import Analyze from "./components/Analyze";
 
+const sections = [
+  { id: "plan", label: "Plan", title: "Plan Your Workouts" },
+  { id: "track", label: "Track", title: "Track Your Runs" },
+  { id: "analyze", label: "Analyze", title: "Analyze Your Progress" },
+] as const;
+
+type Section = (typeof sections)[number]["id"];
+
 function App() {
-  const [activeSection, setActiveSection] = useState<"plan" | "track" | "analyze" | null>(null);
-  
+  const [activeSection, setActiveSection] = useState<Section | null>(null);
+  const lastActiveSection = useRef<Section | null>(null);
+  const triggerRefs = useRef<Record<Section, HTMLButtonElement | null>>({
+    plan: null,
+    track: null,
+    analyze: null,
+  });
+
+  useEffect(() => {
+    if (!activeSection && lastActiveSection.current) {
+      triggerRefs.current[lastActiveSection.current]?.focus();
+      lastActiveSection.current = null;
+    }
+  }, [activeSection]);
+
+  const openSection = (section: Section) => {
+    lastActiveSection.current = section;
+    setActiveSection(section);
+  };
+
+  const closeSection = () => {
+    setActiveSection(null);
+  };
+
+  const activeSectionDetails = sections.find(({ id }) => id === activeSection);
 
   return (
     <motion.div
-      className="main flex flex-col items-center justify-center h-screen"
+      className="main"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 1, ease: "easeOut" }}
     >
-      {/* Login & Signup Buttons – Hidden when a section is active */}
       {!activeSection && (
         <>
           <LoginButton />
@@ -29,80 +59,80 @@ function App() {
         </>
       )}
 
+      {!activeSection && (
+        <nav className="section-navigation" aria-label="Training sections">
+          {sections.map(({ id, label }) => (
+            <motion.button
+              key={id}
+              ref={(element) => {
+                triggerRefs.current[id] = element;
+              }}
+              type="button"
+              className="section-trigger"
+              aria-controls={`${id}-panel`}
+              aria-expanded="false"
+              onClick={() => openSection(id)}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.25 }}
+            >
+              {label}
+            </motion.button>
+          ))}
+        </nav>
+      )}
 
-      <div className="box-container flex gap-4 relative">
-        {(["plan", "track", "analyze"] as const).map((section) => (
-                  <motion.button
-                    key={section}
-                    className="box-under-arrow"
-                    initial={{ width: "50vw", height: "3em" }}
-                    onClick={() => {
-                      if (activeSection !== section) {
-                        setActiveSection(section);
-                      }
-                    }}
-                    animate={{
-                      width: activeSection === section ? "100vw" : "7em",
-                      height: activeSection === section ? "100vh" : "2em",
-                      backgroundColor: activeSection === section ? "white" : "#ffffff",
-                      border: activeSection === section ? "none" : "",
-                      boxShadow: activeSection === section ? "none" : "",
-                    }}
-                    transition={{ duration: .25 }}
-                    style={{
-                      overflow: "hidden",
-                      position: "relative",
-                      zIndex: 1,
-                      cursor: activeSection === section ? "default" : "pointer",
-                    }}
-                  >
-                    {activeSection === section ? (
-                      <SectionContent section={section} onClose={() => setActiveSection(null)} />
-                    ) : (
-                      <p>{section.charAt(0).toUpperCase() + section.slice(1)}</p>
-                    )}
-                  </motion.button>
-        ))}
-      </div>
+      {activeSection && activeSectionDetails && (
+        <motion.section
+          id={`${activeSection}-panel`}
+          className="section-panel"
+          aria-labelledby={`${activeSection}-panel-title`}
+          initial={{ opacity: 0, scale: 0.98 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.25 }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") closeSection();
+          }}
+        >
+          <SectionContent
+            section={activeSection}
+            title={activeSectionDetails.title}
+            onClose={closeSection}
+          />
+        </motion.section>
+      )}
     </motion.div>
   );
 }
 
 type SectionContentProps = {
-  section: "plan" | "track" | "analyze";
+  section: Section;
+  title: string;
   onClose: () => void;
 };
 
-function SectionContent({ section, onClose }: SectionContentProps) {
-  const getTitle = () => {
-    if (section === "plan") return "Plan Your Workouts";
-    if (section === "track") return "Track Your Runs";
-    if (section === "analyze") return "Analyze Your Progress";
-    return "";
-  };
-
+function SectionContent({ section, title, onClose }: SectionContentProps) {
   return (
     <motion.div
-      className="relative z-10"
+      className="section-panel-content"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
-      transition={{ duration: 1 }}
+      transition={{ duration: 0.25 }}
     >
       <button
-        onClick={() => {
-          console.log("Closed section, activeSection:", null);
-          onClose();
-        }}
-        className="close absolute top-4 right-4 text-2xl text-white"
-        style={{ background: "transparent", border: "none", cursor: "pointer" }}
+        type="button"
+        onClick={onClose}
+        className="close"
+        aria-label={`Close ${title} panel`}
+        autoFocus
       >
-        X
+        <span aria-hidden="true">X</span>
       </button>
-      <h1 className="section-heading font-bold">{getTitle()}</h1>
+      <h1 id={`${section}-panel-title`} className="section-heading">{title}</h1>
       {section === "plan" && <Calendar />}
       {section === "track" && <ShoeTracker />}
-      {section === "analyze" && <Analyze/>}
+      {section === "analyze" && <Analyze />}
     </motion.div>
   );
 }

--- a/src/components/Analyze.css
+++ b/src/components/Analyze.css
@@ -1,9 +1,8 @@
 .analyze-container {
   position: relative;
   width: 100%;
-  height: 100%;
+  min-width: 0;
   padding: 20px;
-  overflow-y: auto;
   border-radius: 8px;
   color: #000;
   text-align: center;
@@ -41,7 +40,7 @@
 
 @media (max-width: 768px) {
   .analyze-container {
-    width: 80%;
+    width: 100%;
     margin: 0 auto;
   }
 }

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -30,7 +30,7 @@
 
 .plan-grid {
   display: grid;
-  grid-template-columns: repeat(7, 13%);
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 1vw;
 }
 

--- a/src/components/ShoeTracker.css
+++ b/src/components/ShoeTracker.css
@@ -3,7 +3,7 @@
   align-items: flex-start;
   justify-content: center;
   gap: 2rem;
-  width: 80%;
+  width: min(100%, 900px);
   max-width: 900px;
   margin: auto;
   padding: 2rem;
@@ -12,6 +12,7 @@
 .entry,
 .shoe-tracking {
   flex: 1;
+  min-width: 0;
   padding: 1.5rem;
   border-radius: 8px;
   background: #f9f9f9;
@@ -40,7 +41,12 @@
     flex-direction: column;
     align-items: center;
     gap: 1rem;
-    width: 95%;
-    padding: 1rem;
+    width: 100%;
+    padding: 0;
+  }
+
+  .entry,
+  .shoe-tracking {
+    width: 100%;
   }
 }

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -4,7 +4,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   text-align: center;
 }
@@ -20,16 +23,24 @@
   font-size: 1.55em;
 }
 
-.box-container {
+.section-navigation {
   display: flex;
   justify-content: center;
   gap: 2em;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  padding: 0 1rem;
 }
 
-.box-under-arrow {
+.section-trigger {
   position: relative;
   z-index: 1;
+  flex: 0 0 auto;
   box-sizing: border-box;
+  width: 7rem;
+  min-width: 7rem;
+  min-height: 3rem;
   overflow: hidden;
   border: solid black;
   border-radius: 8px;
@@ -40,12 +51,38 @@
   text-align: center;
 }
 
-.box-under-arrow p {
-  margin: 0;
+.section-panel {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100vw;
+  height: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background-color: #fff;
+  text-align: center;
+}
+
+.section-panel-content {
+  position: relative;
+  box-sizing: border-box;
+  width: min(100%, 1200px);
+  min-height: 100%;
+  margin: 0 auto;
+  padding: 4rem clamp(1rem, 4vw, 3rem) 2rem;
+}
+
+.section-panel *,
+.section-panel *::before,
+.section-panel *::after {
+  box-sizing: border-box;
 }
 
 .section-heading {
-  margin-top: 1em;
+  margin-top: 0;
   margin-bottom: 1em;
   color: black;
   line-height: 1em;
@@ -53,29 +90,35 @@
 
 .close {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  box-sizing: border-box;
-  width: 100%;
-  padding: 5px 10px;
+  top: 1rem;
+  right: 1rem;
+  z-index: 3;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
   border: none;
   border-radius: 4px;
   background-color: #0056b3;
-  color: #000000;
+  color: #fff;
   font-size: 1.5rem;
+  line-height: 1;
   cursor: pointer;
 }
 
 @media (max-width: 768px) {
-  .box-container {
+  .section-navigation {
     flex-direction: column;
     align-items: center;
     width: 100%;
   }
 
-  .box-under-arrow {
+  .section-trigger {
     font-size: 1em;
     line-height: 1.2em;
+  }
+
+  .section-panel-content {
+    padding: 4rem 0.75rem 1.5rem;
   }
 
   .title {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,8 +14,15 @@ html,
 body {
   margin: 0;
   padding: 0;
+  width: 100%;
+  min-height: 100%;
   overflow-x: hidden;
   text-rendering: optimizeLegibility;
+}
+
+#root {
+  width: 100%;
+  min-height: 100%;
 }
 
 button {


### PR DESCRIPTION
## Summary

- render Plan, Track, and Analyze as dedicated trigger buttons only while navigation is collapsed
- render the selected feature in a named semantic region outside every trigger button
- remove inactive triggers while a panel is open so widths no longer compete in the same flex row
- constrain active panels to the viewport with their own vertical scrolling and no horizontal overflow
- move focus into the opened panel, restore it to the originating trigger on close, and support Escape
- add tests for semantic regions, mouse and keyboard transitions, focus, and nested interactive controls

## Linked issues

Closes #1
Closes #2

## Verification

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm test`, 6 files and 15 tests
- [x] `npm run build`
- [x] React no longer reports the nested-button `validateDOMNesting` warning
- [x] Opened and closed Plan, Track, and Analyze with mouse and keyboard
- [x] Verified focus enters the close control and returns to the correct trigger
- [x] Verified desktop layout at 1280 by 720
- [x] Verified mobile layout at 390 by 844
- [x] Measured document and panel scroll widths with no horizontal overflow

## Layout result

Each active panel measures exactly the viewport width at both tested sizes. Track uses intentional vertical scrolling on mobile when its content exceeds the available height. Plan, Track, and Analyze content all remain inside the panel boundaries.

## Notes

This is a focused structural fix using the existing visual design and dependencies. It does not merge or reproduce the deferred modern Track and Analyze prototype from draft PR #44.
