### PR TITLE
feat: integrate Firebase authentication state

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
+import AuthProvider from './auth/AuthProvider'
+import {
+  logOut,
+  subscribeToAuthState,
+  type AuthUser
+} from './services/authService'
 
-// Keep these tests focused on App state instead of animation timing.
 vi.mock('framer-motion', () => ({
   motion: {
     button: 'button',
@@ -13,9 +18,22 @@ vi.mock('framer-motion', () => ({
 }))
 
 vi.mock('./services/authService', () => ({
+  logOut: vi.fn(),
   signIn: vi.fn(),
-  signUp: vi.fn()
+  signUp: vi.fn(),
+  subscribeToAuthState: vi.fn()
 }))
+
+const mockedLogOut = vi.mocked(logOut)
+const mockedSubscribeToAuthState = vi.mocked(subscribeToAuthState)
+const signedInUser: AuthUser = {
+  uid: 'runner-1',
+  email: 'runner@example.com'
+}
+
+let emitAuthState: (user: AuthUser | null) => void
+let emitAuthError: (error: Error) => void
+let unsubscribe: ReturnType<typeof vi.fn>
 
 const sectionTransitions = [
   ['Plan', 'Plan Your Workouts'],
@@ -23,9 +41,134 @@ const sectionTransitions = [
   ['Analyze', 'Analyze Your Progress']
 ] as const
 
-describe('App', () => {
-  it('renders the initial training companion screen', () => {
-    render(<App />)
+function renderApp() {
+  return render(
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  )
+}
+
+function renderSignedInApp() {
+  const view = renderApp()
+
+  act(() => {
+    emitAuthState(signedInUser)
+  })
+
+  return view
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  unsubscribe = vi.fn()
+  mockedLogOut.mockResolvedValue()
+  mockedSubscribeToAuthState.mockImplementation((onChange, onError) => {
+    emitAuthState = onChange
+    emitAuthError = onError ?? (() => undefined)
+    return unsubscribe
+  })
+})
+
+describe('App authentication state', () => {
+  it('shows loading while Firebase resolves the session and cleans up its listener', () => {
+    const { unmount } = renderApp()
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Loading your session...'
+    )
+    expect(screen.queryByRole('button', { name: 'Login' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument()
+
+    unmount()
+
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('shows signed-out controls and gates personal training features', () => {
+    renderApp()
+
+    act(() => {
+      emitAuthState(null)
+    })
+
+    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sign Up' })).toBeInTheDocument()
+    expect(
+      screen.getByText(/sign in or create an account to access/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('navigation', { name: 'Training sections' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('updates the UI when Firebase reports a signed-in session', () => {
+    renderApp()
+
+    act(() => {
+      emitAuthState(null)
+    })
+    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
+
+    act(() => {
+      emitAuthState(signedInUser)
+    })
+
+    expect(screen.getByText('Signed in as runner@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Log out' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('navigation', { name: 'Training sections' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Login' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('returns to signed-out UI after logout', async () => {
+    const user = userEvent.setup()
+    renderSignedInApp()
+
+    await user.click(screen.getByRole('button', { name: 'Log out' }))
+
+    expect(mockedLogOut).toHaveBeenCalledOnce()
+
+    act(() => {
+      emitAuthState(null)
+    })
+
+    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('navigation', { name: 'Training sections' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a calm error when logout fails', async () => {
+    const user = userEvent.setup()
+    mockedLogOut.mockRejectedValue(new Error('Network unavailable'))
+    renderSignedInApp()
+
+    await user.click(screen.getByRole('button', { name: 'Log out' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "We couldn't log you out. Please try again."
+    )
+  })
+
+  it('resolves an authentication subscription error to signed-out UI', () => {
+    renderApp()
+
+    act(() => {
+      emitAuthError(new Error('Unable to restore session'))
+    })
+
+    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+})
+
+describe('App training sections', () => {
+  it('renders the signed-in training companion screen', () => {
+    renderSignedInApp()
 
     expect(
       screen.getByRole('heading', { level: 1, name: 'Marathoner.' })
@@ -33,21 +176,16 @@ describe('App', () => {
     expect(
       screen.getByText('Welcome to your training companion')
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Sign Up' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Plan' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Track' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Analyze' })).toBeInTheDocument()
-    expect(
-      screen.getByRole('navigation', { name: 'Training sections' })
-    ).toBeInTheDocument()
   })
 
   it.each(sectionTransitions)(
     'opens and closes the %s section',
     async (sectionName, sectionHeading) => {
       const user = userEvent.setup()
-      render(<App />)
+      renderSignedInApp()
 
       const sectionTrigger = screen.getByRole('button', { name: sectionName })
       await user.click(sectionTrigger)
@@ -60,9 +198,6 @@ describe('App', () => {
       ).toBeInTheDocument()
       expect(
         screen.queryByRole('heading', { level: 1, name: 'Marathoner.' })
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole('navigation', { name: 'Training sections' })
       ).not.toBeInTheDocument()
 
       const closeButton = screen.getByRole('button', {
@@ -83,7 +218,7 @@ describe('App', () => {
 
   it('opens and closes a section with the keyboard', async () => {
     const user = userEvent.setup()
-    render(<App />)
+    renderSignedInApp()
 
     const planTrigger = screen.getByRole('button', { name: 'Plan' })
     planTrigger.focus()
@@ -102,7 +237,7 @@ describe('App', () => {
 
   it('keeps panel controls outside the section trigger buttons', async () => {
     const user = userEvent.setup()
-    render(<App />)
+    renderSignedInApp()
 
     await user.click(screen.getByRole('button', { name: 'Track' }))
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Calendar from "./components/Calendar";
 import SignUpButton from "./components/SignUpButton";
 import ShoeTracker from "./components/ShoeTracker";
 import Analyze from "./components/Analyze";
+import { useAuth } from "./auth/useAuth";
 
 const sections = [
   { id: "plan", label: "Plan", title: "Plan Your Workouts" },
@@ -17,7 +18,9 @@ const sections = [
 type Section = (typeof sections)[number]["id"];
 
 function App() {
+  const auth = useAuth();
   const [activeSection, setActiveSection] = useState<Section | null>(null);
+  const [logoutError, setLogoutError] = useState<string | null>(null);
   const lastActiveSection = useRef<Section | null>(null);
   const triggerRefs = useRef<Record<Section, HTMLButtonElement | null>>({
     plan: null,
@@ -32,6 +35,13 @@ function App() {
     }
   }, [activeSection]);
 
+  useEffect(() => {
+    if (auth.status !== "signedIn") {
+      setActiveSection(null);
+      setLogoutError(null);
+    }
+  }, [auth.status]);
+
   const openSection = (section: Section) => {
     lastActiveSection.current = section;
     setActiveSection(section);
@@ -39,6 +49,16 @@ function App() {
 
   const closeSection = () => {
     setActiveSection(null);
+  };
+
+  const handleLogout = async () => {
+    setLogoutError(null);
+
+    try {
+      await auth.logout();
+    } catch {
+      setLogoutError("We couldn't log you out. Please try again.");
+    }
   };
 
   const activeSectionDetails = sections.find(({ id }) => id === activeSection);
@@ -50,16 +70,53 @@ function App() {
       animate={{ opacity: 1 }}
       transition={{ duration: 1, ease: "easeOut" }}
     >
-      {!activeSection && (
+      {auth.status === "loading" && (
         <>
-          <LoginButton />
-          <SignUpButton />
           <Title />
-          <Subtitle />
+          <p className="auth-message" role="status">
+            Loading your session...
+          </p>
         </>
       )}
 
-      {!activeSection && (
+      {auth.status !== "loading" && !activeSection && (
+        <>
+          {auth.status === "signedOut" ? (
+            <>
+              <LoginButton />
+              <SignUpButton />
+            </>
+          ) : (
+            <div className="session-controls">
+              <p className="session-user">
+                Signed in as {auth.user.email ?? "Marathoner user"}
+              </p>
+              <button
+                type="button"
+                className="logout-btn"
+                onClick={handleLogout}
+              >
+                Log out
+              </button>
+            </div>
+          )}
+          <Title />
+          <Subtitle />
+          {auth.status === "signedOut" && (
+            <p className="auth-message">
+              Sign in or create an account to access your training plan, run
+              tracker, and progress.
+            </p>
+          )}
+          {logoutError && (
+            <p className="auth-message auth-error" role="alert">
+              {logoutError}
+            </p>
+          )}
+        </>
+      )}
+
+      {auth.status === "signedIn" && !activeSection && (
         <nav className="section-navigation" aria-label="Training sections">
           {sections.map(({ id, label }) => (
             <motion.button
@@ -82,7 +139,7 @@ function App() {
         </nav>
       )}
 
-      {activeSection && activeSectionDetails && (
+      {auth.status === "signedIn" && activeSection && activeSectionDetails && (
         <motion.section
           id={`${activeSection}-panel`}
           className="section-panel"

--- a/src/auth/AuthContext.ts
+++ b/src/auth/AuthContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from "react";
+import type { AuthUser } from "../services/authService";
+
+export type AuthSession =
+  | { status: "loading"; user: null }
+  | { status: "signedOut"; user: null }
+  | { status: "signedIn"; user: AuthUser };
+
+export type AuthContextValue = AuthSession & {
+  logout: () => Promise<void>;
+};
+
+export const AuthContext = createContext<AuthContextValue | undefined>(
+  undefined,
+);

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { logOut, subscribeToAuthState } from "../services/authService";
+import { AuthContext, type AuthSession } from "./AuthContext";
+
+type AuthProviderProps = {
+  children: ReactNode;
+};
+
+export default function AuthProvider({ children }: AuthProviderProps) {
+  const [session, setSession] = useState<AuthSession>({
+    status: "loading",
+    user: null,
+  });
+
+  useEffect(
+    () =>
+      subscribeToAuthState(
+        (user) => {
+          setSession(
+            user
+              ? { status: "signedIn", user }
+              : { status: "signedOut", user: null },
+          );
+        },
+        () => {
+          setSession({ status: "signedOut", user: null });
+        },
+      ),
+    [],
+  );
+
+  return (
+    <AuthContext.Provider value={{ ...session, logout: logOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { AuthContext } from "./AuthContext";
+
+export function useAuth() {
+  const auth = useContext(AuthContext);
+
+  if (!auth) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+
+  return auth;
+}

--- a/src/components/Authentication.css
+++ b/src/components/Authentication.css
@@ -25,9 +25,49 @@
 }
 
 .login-btn:hover,
-.signup-btn:hover {
+.signup-btn:hover,
+.logout-btn:hover {
   background-color: white;
   color: black;
+}
+
+.session-controls {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  line-height: 1.2;
+}
+
+.session-user {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.logout-btn {
+  box-sizing: border-box;
+  width: auto;
+  padding: 10px 20px;
+  border: solid;
+  border-radius: 5px;
+  background-color: white;
+  box-shadow: 0 1em 0.5em rgb(204, 204, 204);
+  color: black;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.auth-message {
+  max-width: 32rem;
+  margin: 1.5rem 1rem 0;
+  color: #454545;
+  line-height: 1.5;
+}
+
+.auth-error {
+  color: #9f1d1d;
 }
 
 .login-wrapper,
@@ -88,4 +128,19 @@
 
 .login-popup button:hover {
   background: #0056b3;
+}
+
+@media (max-width: 768px) {
+  .session-controls {
+    right: 16px;
+    left: 16px;
+    justify-content: flex-end;
+  }
+
+  .session-user {
+    max-width: min(55vw, 18rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,26 +1,22 @@
 import { useState, useRef, useEffect } from "react";
-import { signIn } from "../services/authService"; // Import the signIn function from authService
+import { signIn } from "../services/authService";
 
 const LoginForm = ({ onClose }: { onClose: () => void }) => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null); // To handle error messages
+  const [error, setError] = useState<string | null>(null);
   const formRef = useRef<HTMLDivElement>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      // Call the signIn function from authService to log in the user
-      const user = await signIn(username, password); // Passing username (email) and password to Firebase
-      console.log("User logged in:", user); // You can use this to handle the logged-in user (e.g., redirect)
-      onClose(); // Close the form after successful login
+      await signIn(username, password);
+      onClose();
     } catch (error) {
-      // Handle any error that occurs during login (e.g., incorrect credentials)
       setError(error instanceof Error ? error.message : "An unexpected error occurred");
     }
   };
 
-  // Close login form when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (formRef.current && !formRef.current.contains(event.target as Node)) {
@@ -36,7 +32,7 @@ const LoginForm = ({ onClose }: { onClose: () => void }) => {
     <div ref={formRef} className="login-popup">
       <form onSubmit={handleSubmit}>
         <span>Login</span>
-        {error && <div className="error">{error}</div>} {/* Display error message if any */}
+        {error && <div className="error">{error}</div>}
         <input
           type="text"
           placeholder="Username (Email)"
@@ -56,4 +52,3 @@ const LoginForm = ({ onClose }: { onClose: () => void }) => {
 };
 
 export default LoginForm;
-

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -1,26 +1,22 @@
 import { useState, useRef, useEffect } from "react";
-import { signUp } from "../services/authService"; // Import the signUp function
+import { signUp } from "../services/authService";
 
 const SignUpForm = ({ onClose }: { onClose: () => void }) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null); // State to hold any error message
+  const [error, setError] = useState<string | null>(null);
   const formRef = useRef<HTMLDivElement>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      // Call the signUp function from authService
-      const user = await signUp(email, password); // Using the signUp function
-      console.log("User signed up:", user); // You can do something with the user here, like redirecting or showing a success message
-      onClose(); // Close the form after successful sign up
+      await signUp(email, password);
+      onClose();
     } catch (error) {
-      // If there's an error, display the message
       setError(error instanceof Error ? error.message : "An unexpected error occurred");
     }
   };
 
-  // Close signup form when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (formRef.current && !formRef.current.contains(event.target as Node)) {
@@ -36,7 +32,7 @@ const SignUpForm = ({ onClose }: { onClose: () => void }) => {
     <div ref={formRef} className="signup-popup">
       <form onSubmit={handleSubmit}>
         <span>Sign Up</span>
-        {error && <div className="error">{error}</div>} {/* Display error message if any */}
+        {error && <div className="error">{error}</div>}
         <input
           type="text"
           placeholder="Email"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import AuthProvider from './auth/AuthProvider.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,48 +1,74 @@
-// src/services/authService.ts
-
 import { initializeApp } from "firebase/app";
-import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, onAuthStateChanged, User } from "firebase/auth";
-import { firebaseConfig } from '../firebaseConfig';  // Import the Firebase config
+import {
+  createUserWithEmailAndPassword,
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signOut,
+  type Unsubscribe,
+  type User,
+} from "firebase/auth";
+import { firebaseConfig } from "../firebaseConfig";
 
-// Initialize Firebase app with the imported config
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 
-// Sign up function
-export const signUp = async (email: string, password: string): Promise<User | null> => {
+export type AuthUser = Pick<User, "uid" | "email">;
+
+export const signUp = async (
+  email: string,
+  password: string,
+): Promise<User> => {
   try {
-    const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+    const userCredential = await createUserWithEmailAndPassword(
+      auth,
+      email,
+      password,
+    );
     return userCredential.user;
   } catch (error) {
-    throw new Error(error instanceof Error ? error.message : 'An unexpected error occurred');
+    throw new Error(
+      error instanceof Error ? error.message : "An unexpected error occurred",
+    );
   }
 };
 
-// Sign in function
-export const signIn = async (email: string, password: string): Promise<User | null> => {
+export const signIn = async (
+  email: string,
+  password: string,
+): Promise<User> => {
   try {
-    const userCredential = await signInWithEmailAndPassword(auth, email, password);
+    const userCredential = await signInWithEmailAndPassword(
+      auth,
+      email,
+      password,
+    );
     return userCredential.user;
   } catch (error) {
-    throw new Error(error instanceof Error ? error.message : 'An unexpected error occurred');
+    throw new Error(
+      error instanceof Error ? error.message : "An unexpected error occurred",
+    );
   }
 };
 
-// Sign out function
 export const logOut = async (): Promise<void> => {
   try {
     await signOut(auth);
   } catch (error) {
-    throw new Error(error instanceof Error ? error.message : 'An unexpected error occurred');
+    throw new Error(
+      error instanceof Error ? error.message : "An unexpected error occurred",
+    );
   }
 };
 
-// Check if the user is authenticated
-export const onAuthStateChangedListener = (callback: (user: User | null) => void): void => {
-  onAuthStateChanged(auth, callback);
-};
-
-// Get the current user
-export const getCurrentUser = (): User | null => {
-  return auth.currentUser;
-};
+export const subscribeToAuthState = (
+  onChange: (user: AuthUser | null) => void,
+  onError?: (error: Error) => void,
+): Unsubscribe =>
+  onAuthStateChanged(
+    auth,
+    (user) => {
+      onChange(user ? { uid: user.uid, email: user.email } : null);
+    },
+    onError,
+  );


### PR DESCRIPTION
## Summary

- add an application-level authentication provider that subscribes to Firebase and returns the unsubscribe function during cleanup
- model loading, signed-out, and signed-in states explicitly
- show Login and Sign Up while signed out, then show the user email and Logout while signed in
- gate Plan, Track, and Analyze as personal signed-in features
- update the UI immediately when Firebase reports a session change
- remove successful-auth console logging now that session state drives the interface

## Linked issue

Closes #5

## Verification

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm test`, 6 files and 21 tests
- [x] `npm run build`
- [x] Verified loading, signed-out, signed-in, logout, logout failure, subscription failure, and listener cleanup in tests
- [x] Verified the real signed-out state in the local browser
- [x] Verified Login remains inside a 390-pixel mobile viewport with no horizontal overflow
- [x] Verified existing feature-panel behavior remains covered for authenticated users

## Notes

Plan, Track, and Analyze are treated as authenticated features because they contain personal training data.

Firebase's auth observer restores its persisted browser session on reload. The provider remains in the loading state until that observer reports the current user or confirms that the user is signed out.

Signed-in and logout transitions are tested at the Firebase subscription boundary without creating test credentials or production user data. The temporary moving-background prototype is not included in this pull request.
