### PR TITLE
feat: define shared training domain model

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ not have an application server, API, router, or training-data database.
 | `src/main.tsx` | Mounts the application in React strict mode and loads the global stylesheet. |
 | `src/App.tsx` | Owns the active Plan, Track, or Analyze section and renders the application shell. |
 | `src/components/` | Contains the feature views, authentication forms, title, subtitle, and supporting UI. |
+| `src/domain/training/` | Defines shared training entities, identifiers, units, validation, and calculations without React or Firebase dependencies. |
 | `src/services/authService.ts` | Initializes Firebase and contains the authentication operations. |
 | `src/firebaseConfig.ts` | Identifies the Firebase web project used by the client. |
 | `src/**/*.test.ts(x)` | Keeps unit and component tests beside the code they verify. |
@@ -59,10 +60,11 @@ The current application flow is deliberately small:
    screen.
 5. Login and signup forms call the Firebase authentication service directly.
 
-There is no shared domain model or application-wide state container yet. Those
-boundaries will be introduced through the Foundation milestone rather than
-added speculatively to the prototype. The shared training model is tracked in
-[issue #11](https://github.com/tulloch022/marathoner/issues/11).
+The shared training domain model is documented in
+[`docs/architecture/training-domain-model.md`](docs/architecture/training-domain-model.md).
+The current prototype components have not been connected to that model or to an
+application-wide state container yet. Persistence and feature integration will
+be introduced through the remaining Foundation work.
 
 ## Current data limitations
 
@@ -224,9 +226,9 @@ When writing tests:
 - Keep each test focused on one observable behavior and give it a description
   that explains the expected outcome.
 
-The current suite covers the initial App screen and section transitions,
-calendar week selection and workout details, shoe creation and run logging,
-authentication error states, and the sample analytics summary.
+The current suite covers the shared training model, initial App screen and
+section transitions, calendar week selection and workout details, shoe creation
+and run logging, authentication error states, and the sample analytics summary.
 
 Known testing boundaries remain visible:
 

--- a/docs/architecture/training-domain-model.md
+++ b/docs/architecture/training-domain-model.md
@@ -1,0 +1,93 @@
+# Training domain model
+
+This document defines the shared language used by Marathoner's Plan, Track, and
+Analyze features. The model contains product data only. React state, open panels,
+selected weeks, form text, and loading indicators remain view state and do not
+belong here.
+
+## Entities and relationships
+
+| Entity | Purpose | Relationships |
+| --- | --- | --- |
+| `UserProfile` | Stores the runner's minimal application preferences. | Its `id` is the owner ID used by all other entities. |
+| `TrainingPlan` | Represents one first-marathon journey over a defined date range. | Belongs to one user and owns many planned workouts. |
+| `PlannedWorkout` | Describes a rest, run, or walk-run assignment on a local calendar day. | Belongs to one user and one training plan. |
+| `CompletedRun` | Records what the runner actually completed. | Belongs to one user and may reference one planned workout and one shoe. |
+| `Shoe` | Represents a pair of shoes that can accumulate run distance. | Belongs to one user and may be referenced by many completed runs. |
+
+A user may eventually have multiple plans, but only one should be active at a
+time. A completed run does not need a planned workout because runners may record
+an extra, imported, or otherwise unplanned run. A run also does not require a
+shoe because some data sources may not provide one.
+
+## Canonical representations
+
+| Concept | Domain representation | Reason |
+| --- | --- | --- |
+| Identifier | Branded string | Prevents accidentally mixing user, plan, workout, run, and shoe IDs in TypeScript. |
+| Distance | Non-negative whole meters | Avoids floating-point persistence drift and supports both miles and kilometers. |
+| Duration | Non-negative whole seconds | Gives runs and calculations one unambiguous time representation. |
+| Pace | Seconds per selected unit, calculated when needed | Prevents persisted pace from disagreeing with distance or duration. |
+| Scheduled date | `YYYY-MM-DD` date-only string | Preserves the runner's intended calendar day without a time-zone conversion. |
+| Event timestamp | UTC ISO 8601 string ending in `Z` | Gives completed runs and audit timestamps a universal point in time. |
+| Time zone | IANA name such as `America/Los_Angeles` | Allows a UTC run timestamp to be presented on the correct local day. |
+
+The interface may continue accepting and displaying miles. Conversion happens at
+the domain boundary. For example, 3 miles becomes 4,828 meters before it is stored.
+
+## Training plan and workout states
+
+A training plan moves among `draft`, `active`, `completed`, and `archived`. A
+user can preserve a finished journey without leaving it active.
+
+A planned workout is `planned`, `completed`, or `skipped`. Its training phase is
+one of the five product-vision phases: learn to run, base building, marathon
+training, race preparation, or recovery.
+
+Workouts are a discriminated union:
+
+- A rest workout has no distance or duration target.
+- A run workout has a purpose and at least one positive distance or duration target.
+- A walk-run workout has at least one positive distance or duration target.
+
+This keeps rest-day data from pretending to be a zero-mile run while supporting
+both distance-based and time-based training.
+
+## Domain invariants
+
+The validation functions enforce rules that TypeScript cannot guarantee when
+data arrives from a form, network request, or database:
+
+1. A plan's target race date cannot precede its start date.
+2. A workout must belong to the same user as its plan.
+3. A workout's date must fall within its plan's inclusive date range.
+4. A run or walk-run workout needs a positive distance or duration target.
+5. A completed run needs positive distance and duration values.
+6. An entity's update timestamp cannot precede its creation timestamp.
+7. A retired shoe has a retirement date, while an active shoe does not.
+8. Text fields that are present cannot contain only whitespace.
+
+Future persistence code must also ensure that every referenced entity belongs to
+the authenticated user. Database security rules remain the final authority for
+cross-user access.
+
+## Calculated data
+
+Pace, total run distance, and shoe mileage are calculated from canonical source
+records. A shoe stores only its starting distance, which supports shoes already
+in use when they are added. Its current mileage is that starting distance plus
+the distances of completed runs associated with it.
+
+These totals should not be persisted as independently editable values. Doing so
+would create two competing sources of truth.
+
+## Example flow
+
+1. Onboarding creates a user profile and a draft training plan.
+2. Approved plan generation creates planned workouts linked to that plan.
+3. Finishing a workout creates a completed run that optionally links to the
+   planned workout and selected shoe.
+4. Plan and Track read the same records, while Analyze derives totals and pace
+   from completed runs.
+5. The persistence layer introduced after this issue converts these domain
+   values to and from database records without exposing Firebase to components.

--- a/src/domain/training/calculations.ts
+++ b/src/domain/training/calculations.ts
@@ -1,0 +1,27 @@
+import type { ShoeId, UserId } from "./identifiers";
+import type { CompletedRun, Shoe } from "./types";
+import { createDistanceMeters, type DistanceMeters } from "./units";
+
+export function calculateTotalDistance(runs: readonly CompletedRun[]): DistanceMeters {
+  const total = runs.reduce((sum, run) => sum + run.distance, 0);
+  return createDistanceMeters(total);
+}
+
+export function calculateShoeDistance(
+  shoe: Shoe,
+  runs: readonly CompletedRun[],
+): DistanceMeters {
+  const loggedDistance = runs
+    .filter((run) => run.userId === shoe.userId && run.shoeId === shoe.id)
+    .reduce((sum, run) => sum + run.distance, 0);
+
+  return createDistanceMeters(shoe.startingDistance + loggedDistance);
+}
+
+export function findRunsForShoe(
+  runs: readonly CompletedRun[],
+  userId: UserId,
+  shoeId: ShoeId,
+): CompletedRun[] {
+  return runs.filter((run) => run.userId === userId && run.shoeId === shoeId);
+}

--- a/src/domain/training/dates.ts
+++ b/src/domain/training/dates.ts
@@ -1,0 +1,87 @@
+declare const dateOnlyBrand: unique symbol;
+declare const utcDateTimeBrand: unique symbol;
+declare const timeZoneBrand: unique symbol;
+
+export type DateOnly = string & { readonly [dateOnlyBrand]: "DateOnly" };
+export type UtcDateTime = string & { readonly [utcDateTimeBrand]: "UtcDateTime" };
+export type IanaTimeZone = string & { readonly [timeZoneBrand]: "IanaTimeZone" };
+
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const UTC_DATE_TIME_PATTERN =
+  /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?Z$/;
+
+export function isDateOnly(value: unknown): value is DateOnly {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const match = DATE_ONLY_PATTERN.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+export function createDateOnly(value: string): DateOnly {
+  if (!isDateOnly(value)) {
+    throw new Error("Date must use the YYYY-MM-DD format and represent a real calendar day.");
+  }
+
+  return value;
+}
+
+export function isUtcDateTime(value: unknown): value is UtcDateTime {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const match = UTC_DATE_TIME_PATTERN.exec(value);
+  if (!match || !isDateOnly(match[1])) {
+    return false;
+  }
+
+  const hour = Number(match[2]);
+  const minute = Number(match[3]);
+  const second = Number(match[4]);
+
+  return hour <= 23 && minute <= 59 && second <= 59 && Number.isFinite(Date.parse(value));
+}
+
+export function createUtcDateTime(value: string): UtcDateTime {
+  if (!isUtcDateTime(value)) {
+    throw new Error("Timestamp must be a valid UTC ISO 8601 value ending in Z.");
+  }
+
+  return new Date(value).toISOString() as UtcDateTime;
+}
+
+export function isIanaTimeZone(value: unknown): value is IanaTimeZone {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createIanaTimeZone(value: string): IanaTimeZone {
+  if (!isIanaTimeZone(value)) {
+    throw new Error("Time zone must be a valid IANA time zone name.");
+  }
+
+  return value;
+}

--- a/src/domain/training/identifiers.ts
+++ b/src/domain/training/identifiers.ts
@@ -1,0 +1,39 @@
+declare const identifierBrand: unique symbol;
+
+type Identifier<EntityName extends string> = string & {
+  readonly [identifierBrand]: EntityName;
+};
+
+export type UserId = Identifier<"User">;
+export type TrainingPlanId = Identifier<"TrainingPlan">;
+export type PlannedWorkoutId = Identifier<"PlannedWorkout">;
+export type CompletedRunId = Identifier<"CompletedRun">;
+export type ShoeId = Identifier<"Shoe">;
+
+function createIdentifier<EntityName extends string>(
+  value: string,
+  entityName: EntityName,
+): Identifier<EntityName> {
+  if (!isIdentifierValue(value)) {
+    throw new Error(`${entityName} identifier must be non-empty and cannot contain slashes.`);
+  }
+
+  return value as Identifier<EntityName>;
+}
+
+export function isIdentifierValue(value: unknown): value is string {
+  return typeof value === "string" && value.trim() === value && value.length > 0 && !value.includes("/");
+}
+
+export const createUserId = (value: string): UserId => createIdentifier(value, "User");
+
+export const createTrainingPlanId = (value: string): TrainingPlanId =>
+  createIdentifier(value, "TrainingPlan");
+
+export const createPlannedWorkoutId = (value: string): PlannedWorkoutId =>
+  createIdentifier(value, "PlannedWorkout");
+
+export const createCompletedRunId = (value: string): CompletedRunId =>
+  createIdentifier(value, "CompletedRun");
+
+export const createShoeId = (value: string): ShoeId => createIdentifier(value, "Shoe");

--- a/src/domain/training/index.ts
+++ b/src/domain/training/index.ts
@@ -1,0 +1,6 @@
+export * from "./calculations";
+export * from "./dates";
+export * from "./identifiers";
+export * from "./types";
+export * from "./units";
+export * from "./validation";

--- a/src/domain/training/training.test.ts
+++ b/src/domain/training/training.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculatePace,
+  calculateShoeDistance,
+  calculateTotalDistance,
+  createCompletedRunId,
+  createDateOnly,
+  createDistanceMeters,
+  createDurationSeconds,
+  createIanaTimeZone,
+  createPlannedWorkoutId,
+  createShoeId,
+  createTrainingPlanId,
+  createUserId,
+  createUtcDateTime,
+  kilometersToMeters,
+  metersToKilometers,
+  metersToMiles,
+  milesToMeters,
+  validateCompletedRun,
+  validatePlannedWorkout,
+  validateShoe,
+  validateTrainingPlan,
+  validateUserProfile,
+  validateWorkoutForPlan,
+  type CompletedRun,
+  type PlannedWorkout,
+  type Shoe,
+  type TrainingPlan,
+  type UserProfile,
+} from ".";
+
+const userId = createUserId("user-1");
+const planId = createTrainingPlanId("plan-1");
+const workoutId = createPlannedWorkoutId("workout-1");
+const shoeId = createShoeId("shoe-1");
+const createdAt = createUtcDateTime("2026-07-28T12:00:00Z");
+const updatedAt = createUtcDateTime("2026-07-28T13:00:00Z");
+
+const profile: UserProfile = {
+  id: userId,
+  displayName: "First-time Marathoner",
+  preferredDistanceUnit: "mile",
+  timeZone: createIanaTimeZone("America/Los_Angeles"),
+  createdAt,
+  updatedAt,
+};
+
+const plan: TrainingPlan = {
+  id: planId,
+  userId,
+  name: "First Marathon Journey",
+  startDate: createDateOnly("2026-08-03"),
+  targetRaceDate: createDateOnly("2027-05-02"),
+  status: "active",
+  createdAt,
+  updatedAt,
+};
+
+const workout: PlannedWorkout = {
+  id: workoutId,
+  userId,
+  planId,
+  scheduledDate: createDateOnly("2026-08-03"),
+  phase: "base_building",
+  status: "planned",
+  kind: "run",
+  purpose: "easy",
+  targetDistance: milesToMeters(3),
+  createdAt,
+  updatedAt,
+};
+
+const shoe: Shoe = {
+  id: shoeId,
+  userId,
+  name: "Daily Trainer",
+  startingDistance: milesToMeters(12),
+  status: "active",
+  createdAt,
+  updatedAt,
+};
+
+const run: CompletedRun = {
+  id: createCompletedRunId("run-1"),
+  userId,
+  plannedWorkoutId: workoutId,
+  shoeId,
+  startedAt: createUtcDateTime("2026-08-03T14:00:00Z"),
+  timeZone: createIanaTimeZone("America/Los_Angeles"),
+  distance: milesToMeters(3),
+  duration: createDurationSeconds(30 * 60),
+  perceivedEffort: "about_right",
+  unusualPain: false,
+  createdAt,
+  updatedAt,
+};
+
+describe("training domain primitives", () => {
+  it("creates distinct identifiers and rejects unsafe document identifiers", () => {
+    expect(createUserId("firebase-user-id")).toBe("firebase-user-id");
+    expect(() => createTrainingPlanId(" ")).toThrow(/non-empty/);
+    expect(() => createShoeId("users/shoe-1")).toThrow(/slashes/);
+  });
+
+  it("accepts real calendar dates and rejects impossible ones", () => {
+    expect(createDateOnly("2028-02-29")).toBe("2028-02-29");
+    expect(() => createDateOnly("2027-02-29")).toThrow(/real calendar day/);
+    expect(() => createDateOnly("02/28/2027")).toThrow(/YYYY-MM-DD/);
+  });
+
+  it("accepts IANA time zones and normalizes UTC timestamps", () => {
+    expect(createIanaTimeZone("America/New_York")).toBe("America/New_York");
+    expect(createUtcDateTime("2026-07-28T12:00:00Z")).toBe("2026-07-28T12:00:00.000Z");
+    expect(() => createIanaTimeZone("Eastern Time")).toThrow(/IANA/);
+    expect(() => createUtcDateTime("2026-07-28T12:00:00-04:00")).toThrow(/UTC/);
+    expect(() => createUtcDateTime("2027-02-29T12:00:00Z")).toThrow(/UTC/);
+    expect(() => createUtcDateTime("2026-07-28Z")).toThrow(/UTC/);
+  });
+
+  it("converts display units to whole meters", () => {
+    expect(milesToMeters(1)).toBe(1609);
+    expect(kilometersToMeters(5)).toBe(5000);
+    expect(metersToMiles(milesToMeters(5))).toBeCloseTo(5, 3);
+    expect(metersToKilometers(kilometersToMeters(5))).toBe(5);
+  });
+
+  it("derives pace from distance and duration", () => {
+    const pace = calculatePace(milesToMeters(5), createDurationSeconds(40 * 60), "mile");
+
+    expect(pace?.secondsPerUnit).toBeCloseTo(480, 0);
+    expect(pace?.unit).toBe("mile");
+    expect(calculatePace(createDistanceMeters(0), createDurationSeconds(60), "mile")).toBeNull();
+  });
+});
+
+describe("training domain validation", () => {
+  it("accepts a representative connected training record", () => {
+    expect(validateUserProfile(profile)).toEqual([]);
+    expect(validateTrainingPlan(plan)).toEqual([]);
+    expect(validatePlannedWorkout(workout)).toEqual([]);
+    expect(validateWorkoutForPlan(workout, plan)).toEqual([]);
+    expect(validateCompletedRun(run)).toEqual([]);
+    expect(validateShoe(shoe)).toEqual([]);
+  });
+
+  it("rejects a plan whose race precedes its start", () => {
+    const invalidPlan: TrainingPlan = {
+      ...plan,
+      startDate: createDateOnly("2027-05-03"),
+    };
+
+    expect(validateTrainingPlan(invalidPlan)).toContainEqual({
+      field: "targetRaceDate",
+      message: "Target race date cannot precede plan start date.",
+    });
+  });
+
+  it("requires a run workout to have a positive distance or duration target", () => {
+    const invalidWorkout: PlannedWorkout = {
+      ...workout,
+      targetDistance: createDistanceMeters(0),
+    };
+
+    expect(validatePlannedWorkout(invalidWorkout)).toContainEqual({
+      field: "targetDistance",
+      message: "A run or walk-run workout needs a positive target distance or duration.",
+    });
+  });
+
+  it("rejects a workout outside its plan or owned by another user", () => {
+    const invalidWorkout: PlannedWorkout = {
+      ...workout,
+      userId: createUserId("user-2"),
+      scheduledDate: createDateOnly("2027-05-03"),
+    };
+
+    expect(validateWorkoutForPlan(invalidWorkout, plan)).toEqual([
+      { field: "userId", message: "Workout and plan must belong to the same user." },
+      {
+        field: "scheduledDate",
+        message: "Workout date must fall within the training plan date range.",
+      },
+    ]);
+  });
+
+  it("requires a completed run to have positive distance and duration", () => {
+    const invalidRun: CompletedRun = {
+      ...run,
+      distance: createDistanceMeters(0),
+      duration: createDurationSeconds(0),
+    };
+
+    expect(validateCompletedRun(invalidRun)).toEqual([
+      { field: "distance", message: "Completed run distance must be positive." },
+      { field: "duration", message: "Completed run duration must be positive." },
+    ]);
+  });
+
+  it("requires retired shoes to include a retirement date", () => {
+    const invalidShoe: Shoe = { ...shoe, status: "retired" };
+
+    expect(validateShoe(invalidShoe)).toContainEqual({
+      field: "retiredOn",
+      message: "A retired shoe needs a retirement date.",
+    });
+  });
+});
+
+describe("training domain calculations", () => {
+  it("totals completed run distance", () => {
+    expect(calculateTotalDistance([run, { ...run, id: createCompletedRunId("run-2") }])).toBe(
+      milesToMeters(6),
+    );
+  });
+
+  it("derives shoe mileage from starting distance and matching runs", () => {
+    const differentShoeRun: CompletedRun = {
+      ...run,
+      id: createCompletedRunId("run-2"),
+      shoeId: createShoeId("shoe-2"),
+      distance: milesToMeters(8),
+    };
+    const differentUserRun: CompletedRun = {
+      ...run,
+      id: createCompletedRunId("run-3"),
+      userId: createUserId("user-2"),
+      distance: milesToMeters(10),
+    };
+
+    expect(calculateShoeDistance(shoe, [run, differentShoeRun, differentUserRun])).toBe(
+      milesToMeters(15),
+    );
+  });
+});

--- a/src/domain/training/types.ts
+++ b/src/domain/training/types.ts
@@ -1,0 +1,103 @@
+import type { DateOnly, IanaTimeZone, UtcDateTime } from "./dates";
+import type {
+  CompletedRunId,
+  PlannedWorkoutId,
+  ShoeId,
+  TrainingPlanId,
+  UserId,
+} from "./identifiers";
+import type { DistanceMeters, DistanceUnit, DurationSeconds } from "./units";
+
+export interface EntityTimestamps {
+  readonly createdAt: UtcDateTime;
+  readonly updatedAt: UtcDateTime;
+}
+
+export interface UserProfile extends EntityTimestamps {
+  readonly id: UserId;
+  readonly displayName?: string;
+  readonly preferredDistanceUnit: DistanceUnit;
+  readonly timeZone: IanaTimeZone;
+}
+
+export type TrainingPlanStatus = "draft" | "active" | "completed" | "archived";
+
+export interface TrainingPlan extends EntityTimestamps {
+  readonly id: TrainingPlanId;
+  readonly userId: UserId;
+  readonly name: string;
+  readonly startDate: DateOnly;
+  readonly targetRaceDate: DateOnly;
+  readonly status: TrainingPlanStatus;
+}
+
+export type TrainingPhase =
+  | "learn_to_run"
+  | "base_building"
+  | "marathon_training"
+  | "race_preparation"
+  | "recovery";
+
+export type WorkoutStatus = "planned" | "completed" | "skipped";
+export type RunPurpose = "easy" | "recovery" | "long" | "tempo" | "intervals" | "race";
+
+interface PlannedWorkoutBase extends EntityTimestamps {
+  readonly id: PlannedWorkoutId;
+  readonly userId: UserId;
+  readonly planId: TrainingPlanId;
+  readonly scheduledDate: DateOnly;
+  readonly phase: TrainingPhase;
+  readonly status: WorkoutStatus;
+  readonly notes?: string;
+}
+
+export interface RestWorkout extends PlannedWorkoutBase {
+  readonly kind: "rest";
+}
+
+export interface RunWorkout extends PlannedWorkoutBase {
+  readonly kind: "run";
+  readonly purpose: RunPurpose;
+  readonly targetDistance?: DistanceMeters;
+  readonly targetDuration?: DurationSeconds;
+}
+
+export interface WalkRunWorkout extends PlannedWorkoutBase {
+  readonly kind: "walk_run";
+  readonly targetDistance?: DistanceMeters;
+  readonly targetDuration?: DurationSeconds;
+}
+
+export type PlannedWorkout = RestWorkout | RunWorkout | WalkRunWorkout;
+
+export type PerceivedEffort =
+  | "much_easier_than_expected"
+  | "easier_than_expected"
+  | "about_right"
+  | "harder_than_expected"
+  | "much_harder_than_expected";
+
+export interface CompletedRun extends EntityTimestamps {
+  readonly id: CompletedRunId;
+  readonly userId: UserId;
+  readonly plannedWorkoutId?: PlannedWorkoutId;
+  readonly shoeId?: ShoeId;
+  readonly startedAt: UtcDateTime;
+  readonly timeZone: IanaTimeZone;
+  readonly distance: DistanceMeters;
+  readonly duration: DurationSeconds;
+  readonly perceivedEffort?: PerceivedEffort;
+  readonly unusualPain?: boolean;
+  readonly notes?: string;
+}
+
+export type ShoeStatus = "active" | "retired";
+
+export interface Shoe extends EntityTimestamps {
+  readonly id: ShoeId;
+  readonly userId: UserId;
+  readonly name: string;
+  readonly startingDistance: DistanceMeters;
+  readonly status: ShoeStatus;
+  readonly retiredOn?: DateOnly;
+}

--- a/src/domain/training/units.ts
+++ b/src/domain/training/units.ts
@@ -1,0 +1,71 @@
+declare const distanceBrand: unique symbol;
+declare const durationBrand: unique symbol;
+
+export type DistanceMeters = number & { readonly [distanceBrand]: "DistanceMeters" };
+export type DurationSeconds = number & { readonly [durationBrand]: "DurationSeconds" };
+export type DistanceUnit = "mile" | "kilometer";
+
+export interface Pace {
+  readonly secondsPerUnit: number;
+  readonly unit: DistanceUnit;
+}
+
+export const METERS_PER_MILE = 1609.344;
+export const METERS_PER_KILOMETER = 1000;
+
+export function createDistanceMeters(value: number): DistanceMeters {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error("Distance must be a non-negative whole number of meters.");
+  }
+
+  return value as DistanceMeters;
+}
+
+export function createDurationSeconds(value: number): DurationSeconds {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error("Duration must be a non-negative whole number of seconds.");
+  }
+
+  return value as DurationSeconds;
+}
+
+export function milesToMeters(miles: number): DistanceMeters {
+  if (!Number.isFinite(miles) || miles < 0) {
+    throw new Error("Miles must be a non-negative number.");
+  }
+
+  return createDistanceMeters(Math.round(miles * METERS_PER_MILE));
+}
+
+export function kilometersToMeters(kilometers: number): DistanceMeters {
+  if (!Number.isFinite(kilometers) || kilometers < 0) {
+    throw new Error("Kilometers must be a non-negative number.");
+  }
+
+  return createDistanceMeters(Math.round(kilometers * METERS_PER_KILOMETER));
+}
+
+export function metersToMiles(meters: DistanceMeters): number {
+  return meters / METERS_PER_MILE;
+}
+
+export function metersToKilometers(meters: DistanceMeters): number {
+  return meters / METERS_PER_KILOMETER;
+}
+
+export function calculatePace(
+  distance: DistanceMeters,
+  duration: DurationSeconds,
+  unit: DistanceUnit,
+): Pace | null {
+  if (distance === 0 || duration === 0) {
+    return null;
+  }
+
+  const metersPerUnit = unit === "mile" ? METERS_PER_MILE : METERS_PER_KILOMETER;
+
+  return {
+    secondsPerUnit: (duration * metersPerUnit) / distance,
+    unit,
+  };
+}

--- a/src/domain/training/validation.ts
+++ b/src/domain/training/validation.ts
@@ -1,0 +1,125 @@
+import type { TrainingPlan, PlannedWorkout, CompletedRun, Shoe, UserProfile } from "./types";
+
+export interface ValidationIssue {
+  readonly field: string;
+  readonly message: string;
+}
+
+function validateText(value: string | undefined, field: string, required: boolean): ValidationIssue[] {
+  if (value === undefined) {
+    return required ? [{ field, message: `${field} is required.` }] : [];
+  }
+
+  if (value.trim().length === 0) {
+    return [{ field, message: `${field} cannot be blank.` }];
+  }
+
+  return [];
+}
+
+function validateTimestamps(entity: { createdAt: string; updatedAt: string }): ValidationIssue[] {
+  if (entity.updatedAt < entity.createdAt) {
+    return [{ field: "updatedAt", message: "updatedAt cannot be earlier than createdAt." }];
+  }
+
+  return [];
+}
+
+export function validateUserProfile(profile: UserProfile): ValidationIssue[] {
+  return [
+    ...validateText(profile.displayName, "displayName", false),
+    ...validateTimestamps(profile),
+  ];
+}
+
+export function validateTrainingPlan(plan: TrainingPlan): ValidationIssue[] {
+  const issues = [
+    ...validateText(plan.name, "name", true),
+    ...validateTimestamps(plan),
+  ];
+
+  if (plan.targetRaceDate < plan.startDate) {
+    issues.push({ field: "targetRaceDate", message: "Target race date cannot precede plan start date." });
+  }
+
+  return issues;
+}
+
+export function validatePlannedWorkout(workout: PlannedWorkout): ValidationIssue[] {
+  const issues = [
+    ...validateText(workout.notes, "notes", false),
+    ...validateTimestamps(workout),
+  ];
+
+  if (workout.kind !== "rest") {
+    const hasPositiveDistance = workout.targetDistance !== undefined && workout.targetDistance > 0;
+    const hasPositiveDuration = workout.targetDuration !== undefined && workout.targetDuration > 0;
+
+    if (!hasPositiveDistance && !hasPositiveDuration) {
+      issues.push({
+        field: "targetDistance",
+        message: "A run or walk-run workout needs a positive target distance or duration.",
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function validateWorkoutForPlan(
+  workout: PlannedWorkout,
+  plan: TrainingPlan,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  if (workout.planId !== plan.id) {
+    issues.push({ field: "planId", message: "Workout must reference the supplied training plan." });
+  }
+
+  if (workout.userId !== plan.userId) {
+    issues.push({ field: "userId", message: "Workout and plan must belong to the same user." });
+  }
+
+  if (workout.scheduledDate < plan.startDate || workout.scheduledDate > plan.targetRaceDate) {
+    issues.push({
+      field: "scheduledDate",
+      message: "Workout date must fall within the training plan date range.",
+    });
+  }
+
+  return issues;
+}
+
+export function validateCompletedRun(run: CompletedRun): ValidationIssue[] {
+  const issues = [
+    ...validateText(run.notes, "notes", false),
+    ...validateTimestamps(run),
+  ];
+
+  if (run.distance <= 0) {
+    issues.push({ field: "distance", message: "Completed run distance must be positive." });
+  }
+
+  if (run.duration <= 0) {
+    issues.push({ field: "duration", message: "Completed run duration must be positive." });
+  }
+
+  return issues;
+}
+
+export function validateShoe(shoe: Shoe): ValidationIssue[] {
+  const issues = [
+    ...validateText(shoe.name, "name", true),
+    ...validateTimestamps(shoe),
+  ];
+
+  if (shoe.status === "retired" && shoe.retiredOn === undefined) {
+    issues.push({ field: "retiredOn", message: "A retired shoe needs a retirement date." });
+  }
+
+  if (shoe.status === "active" && shoe.retiredOn !== undefined) {
+    issues.push({ field: "retiredOn", message: "An active shoe cannot have a retirement date." });
+  }
+
+  return issues;
+}


### PR DESCRIPTION
## Summary
- Define shared user, training plan, planned workout, completed run, and shoe entities.
- Establish typed identifiers plus canonical meters, seconds, calendar dates, UTC timestamps, and IANA time zones.
- Add domain validation, pace and distance calculations, representative valid and invalid tests, and architecture documentation.
- Keep the domain independent of React and Firebase so Plan, Track, Analyze, and future persistence can share it.

## Linked issue
Closes #11

## Verification
- [x] `npm run lint`
- [x] `npm test` (34 tests passed)
- [x] `npm run build`
- [x] Confirmed the visible application behavior is unchanged
- [x] Maintainer reviewed every changed line

## Notes
- Distance is stored as whole meters and duration as whole seconds.
- Pace and shoe mileage are derived rather than independently persisted.
- Firestore integration and component adoption remain follow-up work.