### PR TITLE
feat: connect persisted training features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ data.
 Marathoner is currently a foundation-stage prototype. The existing experience
 includes:
 
-- **Plan:** browse a sample 20-week workout calendar and inspect daily workouts.
-- **Track:** add shoes, log runs, and calculate mileage for the current session.
-- **Analyze:** preview the planned analytics experience with sample data.
+- **Plan:** browse persisted training weeks and inspect planned-workout details.
+- **Track:** persist shoes and runs, associate runs with planned workouts, and
+  edit or delete completed runs.
+- **Analyze:** calculate mileage, pace, and run counts from completed-run history.
 - **Authentication:** create an account and sign in with Firebase email/password
   authentication.
 
-The typed persistence layer can store training plans, workouts, runs, and shoes,
-but the visible prototype features are not connected to it yet. Follow the
+The visible features share the typed Firestore persistence layer. Follow the
 [open issues](https://github.com/tulloch022/marathoner/issues) to see what is
 being built next.
 
@@ -28,7 +28,7 @@ being built next.
 
 - React and TypeScript
 - Vite
-- Firebase Authentication
+- Firebase Authentication and Cloud Firestore
 - Framer Motion
 - Vitest and Testing Library
 - ESLint
@@ -36,8 +36,8 @@ being built next.
 ## Current architecture
 
 Marathoner is currently a client-only, single-page React application. It does
-not have an application server, API, or router. A typed Firestore persistence
-layer is being built, but the prototype features are not connected to it yet.
+not have an application server, API, or router. Its authenticated training data
+uses typed repositories backed by Cloud Firestore.
 
 | Path | Responsibility |
 | --- | --- |
@@ -47,6 +47,7 @@ layer is being built, but the prototype features are not connected to it yet.
 | `src/components/` | Contains the feature views, authentication forms, title, subtitle, and supporting UI. |
 | `src/domain/training/` | Defines shared training entities, identifiers, units, validation, and calculations without React or Firebase dependencies. |
 | `src/persistence/` | Defines typed training repositories, Firestore conversion, storage paths, ownership integration tests, and recoverable persistence errors. |
+| `src/training/` | Owns authenticated training-data loading, shared feature state, and cross-feature mutations. |
 | `src/services/firebaseClient.ts` | Initializes the shared Firebase app and Authentication instance. |
 | `src/services/authService.ts` | Contains authentication operations against the shared Firebase client. |
 | `src/firebaseConfig.ts` | Identifies the Firebase web project used by the client. |
@@ -58,44 +59,31 @@ layer is being built, but the prototype features are not connected to it yet.
 The current application flow is deliberately small:
 
 1. `src/main.tsx` mounts `App`.
-2. `App` keeps the selected section in local React state.
-3. Opening Plan, Track, or Analyze mounts that feature component.
-4. Closing a section unmounts its feature component and returns to the landing
-   screen.
-5. Login and signup forms call the Firebase authentication service directly.
+2. `AuthProvider` resolves the Firebase session and gates personal features.
+3. `TrainingDataProvider` loads repositories for the signed-in user and keeps
+   one shared plan, workout, run, and shoe snapshot.
+4. Opening Plan, Track, or Analyze mounts a view over that shared snapshot.
+5. Feature mutations persist through repositories and update the shared state,
+   so every open panel observes the same records.
 
 The shared training domain model is documented in
 [`docs/architecture/training-domain-model.md`](docs/architecture/training-domain-model.md).
-The current prototype components have not been connected to that model or to an
-application-wide state container yet. Persistence and feature integration will
-be introduced through the remaining Foundation work.
+Cross-feature behavior is documented in
+[`docs/architecture/training-feature-integration.md`](docs/architecture/training-feature-integration.md).
 
 ## Current data limitations
 
-The visible training experience is not connected to persistent user data yet:
-
-- **Plan:** `Calendar.tsx` generates a sample 20-week schedule by repeating one
-  seven-day week. It is not based on dates, goals, experience, or an account.
-  Personalized plan generation is tracked in
+- Personalized plan generation and plan-creation UI are not implemented yet.
+  Accounts without a plan receive an honest empty state. This work is tracked in
   [issue #29](https://github.com/tulloch022/marathoner/issues/29).
-- **Track:** `ShoeTracker.tsx` keeps shoes and runs in component state. Closing
-  Track, refreshing the page, or opening the app on another device clears that
-  data. Persistent training data is tracked in
-  [issue #12](https://github.com/tulloch022/marathoner/issues/12).
-- **Analyze:** `Analyze.tsx` displays fixed demonstration values. It does not
-  calculate results from Plan or Track. Connecting the three features is
-  tracked in [issue #13](https://github.com/tulloch022/marathoner/issues/13).
-- **Authentication:** Firebase can create and sign in accounts, but the
-  application shell does not currently display the signed-in user, react to
-  authentication-state changes, protect content, or expose sign out.
-  Application-level authentication state is tracked in
-  [issue #5](https://github.com/tulloch022/marathoner/issues/5).
-
-No visible workout, run, shoe, or analytics data is sent to Firestore yet. The
-typed persistence foundation and security model are documented in
-[`docs/architecture/training-data-persistence.md`](docs/architecture/training-data-persistence.md),
-but feature integration remains part of issue #13. Firebase Authentication is
-currently the only remote operation initiated by the visible application.
+- Training data loads as a persisted snapshot. Mutations remain synchronized
+  inside the current session, while real-time cross-device listeners remain a
+  future enhancement.
+- The first Track form captures date, distance, elapsed time, shoe, and optional
+  planned-workout association. Perceived effort and the remaining coaching
+  inputs will be added in later product slices.
+- Firestore structure and security behavior are documented in
+  [`docs/architecture/training-data-persistence.md`](docs/architecture/training-data-persistence.md).
 
 ## Prerequisites
 
@@ -138,17 +126,16 @@ that exactly matches `package-lock.json`.
 
 ## Firebase configuration
 
-Firebase currently performs email/password authentication and supplies the
-Firestore client for the persistence layer under construction. The web client
+Firebase performs email/password authentication and supplies the Firestore
+client for persisted training data. The web client
 configuration is defined in `src/firebaseConfig.ts`. Importing
 `src/services/firebaseClient.ts` initializes one shared Firebase app and creates
 the Authentication instance. The persistence entry point creates Firestore from
 that same app only when training repositories are requested.
 
-The service exports operations for signup, sign in, sign out, reading the
-current user, and subscribing to authentication changes. The current UI uses
-only signup and sign in. Firebase may retain an authenticated browser session,
-but the rest of the application does not consume that session yet.
+The authentication service exports operations for signup, sign in, sign out,
+reading the current user, and subscribing to authentication changes. The
+training-data provider uses the authenticated UID as its ownership boundary.
 
 The committed configuration connects the app to its current Firebase project.
 To use a different project:
@@ -237,8 +224,8 @@ When writing tests:
   that explains the expected outcome.
 
 The current suite covers the shared training model, initial App screen and
-section transitions, calendar week selection and workout details, shoe creation
-and run logging, authentication error states, and the sample analytics summary.
+section transitions, persisted calendar views, shoe and run mutations,
+authentication error states, derived analytics, and cross-feature consistency.
 
 Known testing boundaries remain visible:
 
@@ -246,9 +233,6 @@ Known testing boundaries remain visible:
   [issue #1](https://github.com/tulloch022/marathoner/issues/1).
 - Firestore integration tests require Java and run separately with
   `npm run test:firestore`; they are not part of the fast jsdom unit suite.
-- Analytics assertions currently describe sample values until
-  [issue #13](https://github.com/tulloch022/marathoner/issues/13) connects them
-  to training data.
 
 ## Validate a change
 

--- a/docs/architecture/training-data-persistence.md
+++ b/docs/architecture/training-data-persistence.md
@@ -181,9 +181,8 @@ plan-field validation, and an end-to-end repository round trip for a related
 plan, workout, shoe, and run. The Firebase emulator requires a local Java
 runtime.
 
-After this change is reviewed and merged, deploy the tested rules and empty
-index configuration to the Marathoner Firebase project before connecting the
-visible features:
+Deploy the tested rules and empty index configuration to the Marathoner Firebase
+project before using the connected features against production Firestore:
 
 ```bash
 npx firebase deploy --project marathoner-d9bf9 --only firestore
@@ -191,6 +190,5 @@ npx firebase deploy --project marathoner-d9bf9 --only firestore
 
 This is an explicit production operation, not part of the local test command.
 
-Plan, Track, and Analyze are not connected to these repositories by issue #12.
-That cross-feature work remains tracked by issue #13 after the persistence
-layer and authorization behavior are complete.
+Plan, Track, and Analyze integration is documented in
+[`training-feature-integration.md`](training-feature-integration.md).

--- a/docs/architecture/training-feature-integration.md
+++ b/docs/architecture/training-feature-integration.md
@@ -1,0 +1,81 @@
+# Training feature integration
+
+## Purpose
+
+Plan, Track, and Analyze use one authenticated training-data state. The state is
+loaded through the typed repositories introduced by issue #12 and remains above
+the individual feature panels, so closing one panel does not discard data.
+
+`TrainingDataProvider` owns repository access and cross-feature mutations.
+Calendar, ShoeTracker, and Analyze receive domain records and callbacks as
+props. This keeps the views testable without Firebase and prevents components
+from constructing database paths.
+
+## Loading and ownership
+
+The provider is created only for a signed-in Firebase user. It converts the
+Firebase UID to the shared `UserId`, dynamically loads the Firestore repository,
+then loads plans, workouts, completed runs, and shoes for that owner.
+
+Dynamic loading keeps the Firestore persistence chunk out of the initial
+signed-out application bundle. A failed load produces a recoverable error with
+a retry action. Signing out unmounts the provider and clears the in-memory
+training snapshot.
+
+## Plan behavior
+
+The Plan panel chooses the active plan first, then a draft plan, then the first
+non-archived plan. It renders persisted workouts in calendar weeks beginning on
+the plan start date.
+
+An account without a plan receives an explicit empty state. Marathoner does not
+silently recreate the old repeated sample schedule. Personalized plan creation
+remains tracked by issue #29.
+
+## Completion rules
+
+- An unplanned run has no workout association. It still contributes to all run,
+  pace, mileage, and shoe calculations.
+- A run can be associated only with a run or walk/run workout that is still
+  planned. Rest days cannot receive run completion records.
+- Creating an associated run changes the planned workout status to `completed`.
+  The completed run is the explicit record of what actually happened.
+- A run shorter or longer than its target still completes the workout. Actual
+  distance and duration remain visible in the run record instead of rewriting
+  the original target.
+- The current interaction allows one completion record per planned workout.
+- If completion-status persistence fails after creating a run, the provider
+  deletes that run so the two records do not visibly disagree.
+
+## Edit and deletion rules
+
+Editing run distance, duration, or shoe association updates the completed run.
+Every dependent value is derived again from the updated run collection. There
+is no separately incremented analytics or shoe-mileage total to drift.
+
+Deleting an unplanned run removes it from every calculation. Deleting the only
+completion record associated with a workout changes that workout back to
+`planned`. If deletion fails after reopening the workout, the provider restores
+the completed status as a compensating operation.
+
+## Analytics definitions
+
+| Value | Definition |
+| --- | --- |
+| Total mileage | Sum of every completed-run distance. |
+| Weekly mileage | Sum of completed runs whose local run date falls in the current Monday-through-Sunday week. |
+| Average pace | Total duration divided by total distance across all completed runs. |
+| Total runs | Number of completed-run records. |
+| Runs this week | Number of completed runs in the current Monday-through-Sunday week. |
+| Shoe mileage | Shoe starting distance plus distances from completed runs associated with that shoe. |
+
+The run's stored IANA time zone determines its local calendar date. Empty data
+shows zero totals and an explicit not-enough-data pace rather than demonstration
+values.
+
+## Current boundary
+
+The provider loads a snapshot when the authenticated experience starts and when
+the user chooses retry. Mutations update both Firestore and that shared snapshot.
+Real-time listeners and cross-device live refresh are future enhancements; a
+new session or page refresh reloads the persisted records.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
 import App from './App'
 import AuthProvider from './auth/AuthProvider'
 import {
@@ -22,6 +23,26 @@ vi.mock('./services/authService', () => ({
   signIn: vi.fn(),
   signUp: vi.fn(),
   subscribeToAuthState: vi.fn()
+}))
+
+vi.mock('./training/TrainingDataProvider', () => ({
+  default: ({ children }: { children: ReactNode }) => children
+}))
+
+vi.mock('./training/useTrainingData', () => ({
+  useTrainingData: () => ({
+    status: 'ready',
+    error: null,
+    plans: [],
+    workouts: [],
+    runs: [],
+    shoes: [],
+    reload: vi.fn(),
+    createShoe: vi.fn(),
+    createRun: vi.fn(),
+    updateRun: vi.fn(),
+    deleteRun: vi.fn()
+  })
 }))
 
 const mockedLogOut = vi.mocked(logOut)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import SignUpButton from "./components/SignUpButton";
 import ShoeTracker from "./components/ShoeTracker";
 import Analyze from "./components/Analyze";
 import { useAuth } from "./auth/useAuth";
+import TrainingDataProvider from "./training/TrainingDataProvider";
+import { useTrainingData } from "./training/useTrainingData";
 
 const sections = [
   { id: "plan", label: "Plan", title: "Plan Your Workouts" },
@@ -116,47 +118,51 @@ function App() {
         </>
       )}
 
-      {auth.status === "signedIn" && !activeSection && (
-        <nav className="section-navigation" aria-label="Training sections">
-          {sections.map(({ id, label }) => (
-            <motion.button
-              key={id}
-              ref={(element) => {
-                triggerRefs.current[id] = element;
-              }}
-              type="button"
-              className="section-trigger"
-              aria-controls={`${id}-panel`}
-              aria-expanded="false"
-              onClick={() => openSection(id)}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.25 }}
-            >
-              {label}
-            </motion.button>
-          ))}
-        </nav>
-      )}
+      {auth.status === "signedIn" && (
+        <TrainingDataProvider userId={auth.user.uid}>
+          {!activeSection && (
+            <nav className="section-navigation" aria-label="Training sections">
+              {sections.map(({ id, label }) => (
+                <motion.button
+                  key={id}
+                  ref={(element) => {
+                    triggerRefs.current[id] = element;
+                  }}
+                  type="button"
+                  className="section-trigger"
+                  aria-controls={`${id}-panel`}
+                  aria-expanded="false"
+                  onClick={() => openSection(id)}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.25 }}
+                >
+                  {label}
+                </motion.button>
+              ))}
+            </nav>
+          )}
 
-      {auth.status === "signedIn" && activeSection && activeSectionDetails && (
-        <motion.section
-          id={`${activeSection}-panel`}
-          className="section-panel"
-          aria-labelledby={`${activeSection}-panel-title`}
-          initial={{ opacity: 0, scale: 0.98 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.25 }}
-          onKeyDown={(event) => {
-            if (event.key === "Escape") closeSection();
-          }}
-        >
-          <SectionContent
-            section={activeSection}
-            title={activeSectionDetails.title}
-            onClose={closeSection}
-          />
-        </motion.section>
+          {activeSection && activeSectionDetails && (
+            <motion.section
+              id={`${activeSection}-panel`}
+              className="section-panel"
+              aria-labelledby={`${activeSection}-panel-title`}
+              initial={{ opacity: 0, scale: 0.98 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.25 }}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") closeSection();
+              }}
+            >
+              <SectionContent
+                section={activeSection}
+                title={activeSectionDetails.title}
+                onClose={closeSection}
+              />
+            </motion.section>
+          )}
+        </TrainingDataProvider>
       )}
     </motion.div>
   );
@@ -169,6 +175,13 @@ type SectionContentProps = {
 };
 
 function SectionContent({ section, title, onClose }: SectionContentProps) {
+  const training = useTrainingData();
+  const activePlan =
+    training.plans.find((plan) => plan.status === "active") ??
+    training.plans.find((plan) => plan.status === "draft") ??
+    training.plans.find((plan) => plan.status !== "archived") ??
+    null;
+
   return (
     <motion.div
       className="section-panel-content"
@@ -187,9 +200,38 @@ function SectionContent({ section, title, onClose }: SectionContentProps) {
         <span aria-hidden="true">X</span>
       </button>
       <h1 id={`${section}-panel-title`} className="section-heading">{title}</h1>
-      {section === "plan" && <Calendar />}
-      {section === "track" && <ShoeTracker />}
-      {section === "analyze" && <Analyze />}
+      {training.status === "loading" && (
+        <p className="training-status" role="status">
+          Loading your training data...
+        </p>
+      )}
+      {training.status === "error" && (
+        <div className="training-error" role="alert">
+          <p>{training.error}</p>
+          <button type="button" onClick={() => void training.reload()}>
+            Try again
+          </button>
+        </div>
+      )}
+      {training.status === "ready" && section === "plan" && (
+        <Calendar plan={activePlan} workouts={training.workouts} />
+      )}
+      {training.status === "ready" && section === "track" && (
+        <ShoeTracker
+          runs={training.runs}
+          shoes={training.shoes}
+          plannedWorkouts={training.workouts.filter(
+            (workout) => workout.planId === activePlan?.id,
+          )}
+          onCreateShoe={training.createShoe}
+          onCreateRun={training.createRun}
+          onUpdateRun={training.updateRun}
+          onDeleteRun={training.deleteRun}
+        />
+      )}
+      {training.status === "ready" && section === "analyze" && (
+        <Analyze runs={training.runs} />
+      )}
     </motion.div>
   );
 }

--- a/src/components/Analyze.test.tsx
+++ b/src/components/Analyze.test.tsx
@@ -1,20 +1,45 @@
-import { render, screen } from '@testing-library/react'
-import { expect, it, vi } from 'vitest'
-import Analyze from './Analyze'
+import { render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import {
+  createCompletedRunId,
+  createDistanceMeters,
+  createDurationSeconds,
+  createIanaTimeZone,
+  createUserId,
+  createUtcDateTime,
+  type CompletedRun,
+} from "../domain/training";
+import Analyze from "./Analyze";
 
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: 'div'
-  }
-}))
+vi.mock("framer-motion", () => ({ motion: { div: "div" } }));
 
-it('shows the current analytics summary', () => {
-  render(<Analyze />)
+const timestamp = createUtcDateTime("2026-08-05T14:00:00Z");
+const run: CompletedRun = {
+  id: createCompletedRunId("run-1"),
+  userId: createUserId("runner-1"),
+  startedAt: timestamp,
+  timeZone: createIanaTimeZone("America/Los_Angeles"),
+  distance: createDistanceMeters(8_047),
+  duration: createDurationSeconds(2_400),
+  createdAt: timestamp,
+  updatedAt: timestamp,
+};
 
-  expect(screen.getByText('Total Mileage')).toBeInTheDocument()
-  expect(screen.getByText('42 mi')).toBeInTheDocument()
-  expect(screen.getByText('Average Pace')).toBeInTheDocument()
-  expect(screen.getByText('7:30 /mi')).toBeInTheDocument()
-  expect(screen.getByText('Runs This Week')).toBeInTheDocument()
-  expect(screen.getByText('5')).toBeInTheDocument()
-})
+it("shows analytics calculated from completed runs", () => {
+  render(<Analyze runs={[run]} now={new Date("2026-08-06T12:00:00Z")} />);
+
+  expect(screen.getByText("Total Mileage")).toBeInTheDocument();
+  expect(screen.getAllByText("5 mi")).toHaveLength(2);
+  expect(screen.getByText("Average Pace")).toBeInTheDocument();
+  expect(screen.getByText("8:00 /mi")).toBeInTheDocument();
+  expect(screen.getByText("Total Runs")).toBeInTheDocument();
+  expect(screen.getAllByText("1")).toHaveLength(2);
+});
+
+it("shows sensible values for an empty history", () => {
+  render(<Analyze runs={[]} now={new Date("2026-08-06T12:00:00Z")} />);
+
+  expect(screen.getByText(/log your first run/i)).toBeInTheDocument();
+  expect(screen.getAllByText("0 mi")).toHaveLength(2);
+  expect(screen.getByText("Not enough data")).toBeInTheDocument();
+});

--- a/src/components/Analyze.tsx
+++ b/src/components/Analyze.tsx
@@ -1,11 +1,41 @@
 import { motion } from "framer-motion";
+import {
+  calculateTrainingAnalytics,
+  createDateOnly,
+  metersToMiles,
+  type CompletedRun,
+  type DistanceMeters,
+} from "../domain/training";
 
-// Remove the onClose prop if not needed
-export default function Analyze() {
-  // Dummy analytics data – replace with real calculations as needed.
-  const totalMileage = 42;
-  const averagePace = "7:30";
-  const runsThisWeek = 5;
+type AnalyzeProps = {
+  readonly runs: readonly CompletedRun[];
+  readonly now?: Date;
+};
+
+function mondayFor(date: Date) {
+  const monday = new Date(date);
+  const day = monday.getDay();
+  monday.setDate(monday.getDate() - (day === 0 ? 6 : day - 1));
+  const year = monday.getFullYear();
+  const month = String(monday.getMonth() + 1).padStart(2, "0");
+  const dayOfMonth = String(monday.getDate()).padStart(2, "0");
+  return createDateOnly(`${year}-${month}-${dayOfMonth}`);
+}
+
+function formatMiles(distance: DistanceMeters): string {
+  return Number(metersToMiles(distance).toFixed(1)).toString();
+}
+
+function formatPace(secondsPerMile: number | undefined): string {
+  if (secondsPerMile === undefined) return "Not enough data";
+  const rounded = Math.round(secondsPerMile);
+  const minutes = Math.floor(rounded / 60);
+  const seconds = String(rounded % 60).padStart(2, "0");
+  return `${minutes}:${seconds} /mi`;
+}
+
+export default function Analyze({ runs, now = new Date() }: AnalyzeProps) {
+  const analytics = calculateTrainingAnalytics(runs, mondayFor(now), "mile");
 
   return (
     <motion.div
@@ -14,18 +44,31 @@ export default function Analyze() {
       animate={{ opacity: 1 }}
       transition={{ duration: 0.8 }}
     >
+      {runs.length === 0 && (
+        <p className="training-empty-state">
+          Log your first run to begin building your training picture.
+        </p>
+      )}
       <div className="analyze-cards">
         <div className="analyze-card">
           <h2>Total Mileage</h2>
-          <p>{totalMileage} mi</p>
+          <p>{formatMiles(analytics.totalDistance)} mi</p>
+        </div>
+        <div className="analyze-card">
+          <h2>This Week</h2>
+          <p>{formatMiles(analytics.weeklyDistance)} mi</p>
         </div>
         <div className="analyze-card">
           <h2>Average Pace</h2>
-          <p>{averagePace} /mi</p>
+          <p>{formatPace(analytics.averagePace?.secondsPerUnit)}</p>
+        </div>
+        <div className="analyze-card">
+          <h2>Total Runs</h2>
+          <p>{analytics.totalRuns}</p>
         </div>
         <div className="analyze-card">
           <h2>Runs This Week</h2>
-          <p>{runsThisWeek}</p>
+          <p>{analytics.runsThisWeek}</p>
         </div>
       </div>
     </motion.div>

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -35,12 +35,22 @@
 }
 
 .plan-day {
+  appearance: none;
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 4px;
   text-align: center;
+  font: inherit;
   cursor: pointer;
   transition: box-shadow 0.3s;
+}
+
+.plan-day.completed {
+  box-shadow: inset 0 0 0 3px #278b57;
+}
+
+.plan-day.skipped {
+  opacity: 0.55;
 }
 
 .plan-day:hover {

--- a/src/components/Calendar.test.tsx
+++ b/src/components/Calendar.test.tsx
@@ -1,44 +1,102 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
-import Calendar from './Calendar'
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import {
+  createDateOnly,
+  createDistanceMeters,
+  createPlannedWorkoutId,
+  createTrainingPlanId,
+  createUserId,
+  createUtcDateTime,
+  type PlannedWorkout,
+  type TrainingPlan,
+} from "../domain/training";
+import Calendar from "./Calendar";
 
-describe('Calendar', () => {
-  it('shows the first week and its total mileage', () => {
-    render(<Calendar />)
+const userId = createUserId("runner-1");
+const planId = createTrainingPlanId("plan-1");
+const timestamp = createUtcDateTime("2026-07-30T12:00:00Z");
+const plan: TrainingPlan = {
+  id: planId,
+  userId,
+  name: "First Marathon Journey",
+  startDate: createDateOnly("2026-08-03"),
+  targetRaceDate: createDateOnly("2026-08-16"),
+  status: "active",
+  createdAt: timestamp,
+  updatedAt: timestamp,
+};
+const workouts: PlannedWorkout[] = [
+  {
+    id: createPlannedWorkoutId("workout-1"),
+    userId,
+    planId,
+    scheduledDate: createDateOnly("2026-08-03"),
+    phase: "base_building",
+    status: "planned",
+    kind: "run",
+    purpose: "easy",
+    targetDistance: createDistanceMeters(4_828),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+  {
+    id: createPlannedWorkoutId("workout-2"),
+    userId,
+    planId,
+    scheduledDate: createDateOnly("2026-08-10"),
+    phase: "base_building",
+    status: "planned",
+    kind: "rest",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+];
 
-    expect(screen.getByRole('combobox')).toHaveValue('1')
-    expect(screen.getByText('Total Mileage: 18 mi')).toBeInTheDocument()
-    expect(screen.getByText('1')).toBeInTheDocument()
-    expect(screen.getByText('7')).toBeInTheDocument()
-  })
+describe("Calendar", () => {
+  it("shows an honest empty state without a plan", () => {
+    render(<Calendar plan={null} workouts={[]} />);
 
-  it('shows the selected training week', async () => {
-    const user = userEvent.setup()
-    render(<Calendar />)
+    expect(screen.getByText(/no training plan yet/i)).toBeInTheDocument();
+  });
 
-    await user.selectOptions(screen.getByRole('combobox'), '2')
+  it("shows persisted workouts and target mileage for the first week", () => {
+    render(<Calendar plan={plan} workouts={workouts} />);
 
-    expect(screen.getByRole('combobox')).toHaveValue('2')
-    expect(screen.getByText('8')).toBeInTheDocument()
-    expect(screen.getByText('14')).toBeInTheDocument()
-    expect(screen.queryByText('1')).not.toBeInTheDocument()
-  })
+    expect(screen.getByRole("combobox", { name: "Training week" })).toHaveValue("1");
+    expect(screen.getByText("Target Mileage: 3 mi")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "2026-08-03: Easy run" }),
+    ).toBeInTheDocument();
+  });
 
-  it('opens and closes a workout detail', async () => {
-    const user = userEvent.setup()
-    render(<Calendar />)
+  it("shows the selected training week", async () => {
+    const user = userEvent.setup();
+    render(<Calendar plan={plan} workouts={workouts} />);
 
-    await user.click(screen.getByText('1'))
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Training week" }),
+      "2",
+    );
 
     expect(
-      screen.getByRole('heading', { level: 3, name: 'Day 1 Details' })
-    ).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'Close' }))
-
+      screen.getByRole("button", { name: "2026-08-10: Rest" }),
+    ).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { level: 3, name: 'Day 1 Details' })
-    ).not.toBeInTheDocument()
-  })
-})
+      screen.queryByRole("button", { name: "2026-08-03: Easy run" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens and closes a persisted workout detail", async () => {
+    const user = userEvent.setup();
+    render(<Calendar plan={plan} workouts={workouts} />);
+
+    await user.click(screen.getByRole("button", { name: "2026-08-03: Easy run" }));
+    expect(
+      screen.getByRole("heading", { name: "2026-08-03 Details" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,132 +1,174 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  metersToMiles,
+  type PlannedWorkout,
+  type TrainingPlan,
+} from "../domain/training";
 
-type Workout = {
-  day: number;
-  type: string;
-  distance: number;
+type CalendarProps = {
+  readonly plan: TrainingPlan | null;
+  readonly workouts: readonly PlannedWorkout[];
 };
 
-// Generate a sample 20-week plan (assuming each week repeats the 7-day structure)
-const generateWorkoutPlan = () => {
-  const baseWeek: Workout[] = [
-    { day: 1, type: "Easy Run", distance: 3 },
-    { day: 2, type: "Easy Run", distance: 3 },
-    { day: 3, type: "Rest", distance: 0 },
-    { day: 4, type: "Tempo Run", distance: 2 },
-    { day: 5, type: "Recovery Run", distance: 2 },
-    { day: 6, type: "Rest", distance: 0 },
-    { day: 7, type: "Long Run", distance: 8 },
-  ];
+const workoutAbbr = {
+  long: "LR",
+  easy: "E",
+  tempo: "T",
+  recovery: "RR",
+  intervals: "I",
+  race: "RACE",
+  walk_run: "WR",
+  rest: "R",
+} as const;
 
-  let fullPlan: Workout[] = [];
-  for (let week = 0; week < 20; week++) {
-    const weekStart = week * 7;
-    const weekPlan = baseWeek.map((workout, index) => ({
-      day: weekStart + index + 1,
-      type: workout.type,
-      distance: workout.distance,
-    }));
-    fullPlan = [...fullPlan, ...weekPlan];
-  }
-  return fullPlan;
-};
-
-const workoutPlan = generateWorkoutPlan();
-
-// Abbreviations for workouts
-const workoutAbbr: Record<string, string> = {
-  "Long Run": "LR",
-  "Easy Run": "E",
-  "Tempo Run": "T",
-  "Recovery Run": "RR",
-  "Rest": "R",
-};
-
-// Return a CSS class based on the workout type
-function getWorkoutColorClass(type: string): string {
-  switch (type) {
-    case "Long Run":
-      return "long-run";
-    case "Easy Run":
-      return "easy-run";
-    case "Tempo Run":
-      return "tempo-run";
-    case "Recovery Run":
-      return "recovery-run";
-    case "Rest":
-      return "rest-day";
-    default:
-      return "";
-  }
+function addDays(date: string, numberOfDays: number): string {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + numberOfDays);
+  return value.toISOString().slice(0, 10);
 }
 
-export default function Plan() {
-  const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);
+function daysBetween(start: string, end: string): number {
+  return Math.floor(
+    (Date.parse(`${end}T00:00:00.000Z`) -
+      Date.parse(`${start}T00:00:00.000Z`)) /
+      86_400_000,
+  );
+}
+
+function workoutLabel(workout: PlannedWorkout): string {
+  if (workout.kind === "rest") return "Rest";
+  if (workout.kind === "walk_run") return "Walk/run";
+  return `${workout.purpose[0].toUpperCase()}${workout.purpose.slice(1)} run`;
+}
+
+function workoutAbbreviation(workout: PlannedWorkout): string {
+  if (workout.kind === "rest") return workoutAbbr.rest;
+  if (workout.kind === "walk_run") return workoutAbbr.walk_run;
+  return workoutAbbr[workout.purpose];
+}
+
+function workoutColorClass(workout: PlannedWorkout): string {
+  if (workout.kind === "rest") return "rest-day";
+  if (workout.kind === "walk_run") return "easy-run";
+  return `${workout.purpose.replace("_", "-")}-run`;
+}
+
+export default function Calendar({ plan, workouts }: CalendarProps) {
+  const [selectedWorkout, setSelectedWorkout] =
+    useState<PlannedWorkout | null>(null);
   const [selectedWeek, setSelectedWeek] = useState(1);
 
-  // Filter workouts based on selected week
-  const startDay = (selectedWeek - 1) * 7 + 1;
-  const endDay = selectedWeek * 7;
-  const weekWorkouts = workoutPlan.filter((w) => w.day >= startDay && w.day <= endDay);
-  const weekMileage = weekWorkouts.reduce((total, w) => total + w.distance, 0);
-
-  const handleWorkoutClick = (workout: Workout) => {
-    setSelectedWorkout(workout);
-  };
-
-  const closeModal = () => {
+  useEffect(() => {
+    setSelectedWeek(1);
     setSelectedWorkout(null);
-  };
+  }, [plan?.id]);
+
+  const weekCount = useMemo(() => {
+    if (plan === null) return 0;
+    return Math.max(1, Math.ceil((daysBetween(plan.startDate, plan.targetRaceDate) + 1) / 7));
+  }, [plan]);
+
+  if (plan === null) {
+    return (
+      <p className="training-empty-state">
+        No training plan yet. Your plan will appear here once it has been created.
+      </p>
+    );
+  }
+
+  const weekStart = addDays(plan.startDate, (selectedWeek - 1) * 7);
+  const weekEnd = addDays(weekStart, 6);
+  const weekWorkouts = workouts.filter(
+    (workout) =>
+      workout.planId === plan.id &&
+      workout.scheduledDate >= weekStart &&
+      workout.scheduledDate <= weekEnd,
+  );
+  const targetMileage = weekWorkouts.reduce(
+    (total, workout) =>
+      total +
+      (workout.kind === "rest" || workout.targetDistance === undefined
+        ? 0
+        : metersToMiles(workout.targetDistance)),
+    0,
+  );
 
   return (
     <div className="plan-container">
-      {/* Header Section */}
       <div className="plan-header">
         <h2 className="section-heading">
-          Training Plan -  
-          <select 
+          {plan.name} Week{" "}
+          <select
+            aria-label="Training week"
             className="week-selector"
             value={selectedWeek}
-            onChange={(e) => setSelectedWeek(parseInt(e.target.value))}
+            onChange={(event) => setSelectedWeek(Number(event.target.value))}
           >
-            {[...Array(20)].map((_, index) => (
-              <option key={index} value={index + 1}>
-                Week {index + 1}
+            {Array.from({ length: weekCount }, (_, index) => (
+              <option key={index + 1} value={index + 1}>
+                {index + 1}
               </option>
             ))}
           </select>
         </h2>
-        <p>Total Mileage: {weekMileage} mi</p>
+        <p>
+          {weekStart} to {weekEnd}
+        </p>
+        <p>Target Mileage: {Number(targetMileage.toFixed(1))} mi</p>
       </div>
 
-      {/* Calendar Grid */}
-      <div className="plan-grid">
-        {weekWorkouts.map((workout) => (
-          <div
-            key={workout.day}
-            className={`plan-day ${getWorkoutColorClass(workout.type)}`}
-            onClick={() => handleWorkoutClick(workout)}
-          >
-            <div className="plan-day-number">{workout.day}</div>
-            <div className="plan-day-abbr">{workoutAbbr[workout.type]}</div>
-          </div>
-        ))}
-      </div>
+      {weekWorkouts.length === 0 ? (
+        <p className="training-empty-state">No workouts are scheduled this week.</p>
+      ) : (
+        <div className="plan-grid">
+          {weekWorkouts.map((workout) => (
+            <button
+              key={workout.id}
+              type="button"
+              className={`plan-day ${workoutColorClass(workout)} ${workout.status}`}
+              onClick={() => setSelectedWorkout(workout)}
+              aria-label={`${workout.scheduledDate}: ${workoutLabel(workout)}`}
+            >
+              <span className="plan-day-number">{workout.scheduledDate.slice(5)}</span>
+              <span className="plan-day-abbr">
+                {workoutAbbreviation(workout)}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
 
-      {/* Detail Modal */}
       {selectedWorkout && (
-        <div className="plan-modal-overlay" onClick={closeModal}>
-          <div className="plan-modal-content" onClick={(e) => e.stopPropagation()}>
-            <h3>Day {selectedWorkout.day} Details</h3>
+        <div
+          className="plan-modal-overlay"
+          onClick={() => setSelectedWorkout(null)}
+        >
+          <div
+            className="plan-modal-content"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="workout-detail-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h3 id="workout-detail-title">
+              {selectedWorkout.scheduledDate} Details
+            </h3>
             <p>
-              <strong>Workout:</strong> {selectedWorkout.type}
+              <strong>Workout:</strong> {workoutLabel(selectedWorkout)}
             </p>
-            {selectedWorkout.distance > 0 && (
-              <p>
-                <strong>Distance:</strong> {selectedWorkout.distance} mi
-              </p>
-            )}
-            <button onClick={closeModal}>Close</button>
+            <p>
+              <strong>Status:</strong> {selectedWorkout.status}
+            </p>
+            {selectedWorkout.kind !== "rest" &&
+              selectedWorkout.targetDistance !== undefined && (
+                <p>
+                  <strong>Distance:</strong>{" "}
+                  {Number(metersToMiles(selectedWorkout.targetDistance).toFixed(1))} mi
+                </p>
+              )}
+            <button type="button" onClick={() => setSelectedWorkout(null)}>
+              Close
+            </button>
           </div>
         </div>
       )}

--- a/src/components/ShoeTracker.css
+++ b/src/components/ShoeTracker.css
@@ -27,9 +27,31 @@
 }
 
 .tracker input,
+.tracker select,
 .tracker button {
   box-sizing: border-box;
   width: 100%;
+}
+
+.tracker form,
+.tracker li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tracker ul {
+  margin: 0;
+  padding: 0;
+}
+
+.training-error {
+  color: #8a1c1c;
+}
+
+.training-empty-state,
+.training-status {
+  color: #555;
 }
 
 .tracker li {

--- a/src/components/ShoeTracker.test.tsx
+++ b/src/components/ShoeTracker.test.tsx
@@ -1,39 +1,166 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
-import ShoeTracker from './ShoeTracker'
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import {
+  createCompletedRunId,
+  createDistanceMeters,
+  createDurationSeconds,
+  createIanaTimeZone,
+  createShoeId,
+  createUserId,
+  createUtcDateTime,
+  type CompletedRun,
+  type Shoe,
+} from "../domain/training";
+import type {
+  CreateCompletedRunInput,
+  CreateShoeInput,
+  UpdateCompletedRunInput,
+} from "../persistence/trainingRepositories";
+import ShoeTracker from "./ShoeTracker";
 
-async function addShoe(name: string) {
-  const user = userEvent.setup()
+const userId = createUserId("runner-1");
+const timestamp = createUtcDateTime("2026-08-05T14:00:00Z");
 
-  await user.type(screen.getByPlaceholderText('Shoe Name'), name)
-  await user.click(screen.getByRole('button', { name: 'Add' }))
+function Harness({
+  initialShoes = [],
+  initialRuns = [],
+}: {
+  initialShoes?: Shoe[];
+  initialRuns?: CompletedRun[];
+}) {
+  const [shoes, setShoes] = useState(initialShoes);
+  const [runs, setRuns] = useState(initialRuns);
 
-  return user
+  const createShoe = async (input: CreateShoeInput) => {
+    const shoe: Shoe = {
+      id: createShoeId(`shoe-${shoes.length + 1}`),
+      userId,
+      name: input.name,
+      startingDistance: input.startingDistance ?? createDistanceMeters(0),
+      status: "active",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    setShoes((current) => [...current, shoe]);
+    return shoe;
+  };
+
+  const createRun = async (input: CreateCompletedRunInput) => {
+    const run: CompletedRun = {
+      ...input,
+      id: createCompletedRunId(`run-${runs.length + 1}`),
+      userId,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    setRuns((current) => [run, ...current]);
+    return run;
+  };
+
+  const updateRun = async (
+    id: CompletedRun["id"],
+    changes: UpdateCompletedRunInput,
+  ) => {
+    const existing = runs.find((run) => run.id === id);
+    if (existing === undefined) throw new Error("Run not found");
+    const updated = {
+      ...existing,
+      distance: changes.distance ?? existing.distance,
+      duration: changes.duration ?? existing.duration,
+      shoeId:
+        changes.shoeId === null ? undefined : changes.shoeId ?? existing.shoeId,
+    };
+    setRuns((current) =>
+      current.map((run) => (run.id === updated.id ? updated : run)),
+    );
+    return updated;
+  };
+
+  const deleteRun = async (id: CompletedRun["id"]) => {
+    setRuns((current) => current.filter((run) => run.id !== id));
+  };
+
+  return (
+    <ShoeTracker
+      runs={runs}
+      shoes={shoes}
+      plannedWorkouts={[]}
+      onCreateShoe={createShoe}
+      onCreateRun={createRun}
+      onUpdateRun={updateRun}
+      onDeleteRun={deleteRun}
+    />
+  );
 }
 
-describe('ShoeTracker', () => {
-  it('adds a shoe with zero starting mileage', async () => {
-    render(<ShoeTracker />)
+async function addShoe(name: string) {
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText("Shoe Name"), name);
+  await user.click(screen.getByRole("button", { name: "Add" }));
+  return user;
+}
 
-    await addShoe('Daily Trainer')
+describe("ShoeTracker", () => {
+  it("adds a persisted shoe with zero starting mileage", async () => {
+    render(<Harness />);
 
-    expect(screen.getByText('Daily Trainer: 0 mi')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Shoe Name')).toHaveValue('')
-  })
+    await addShoe("Daily Trainer");
 
-  it('logs a run and adds its distance to the selected shoe', async () => {
-    render(<ShoeTracker />)
-    const user = await addShoe('Daily Trainer')
+    expect(await screen.findByText("Daily Trainer: 0 mi")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Shoe Name")).toHaveValue("");
+  });
 
-    await user.type(screen.getByPlaceholderText('Miles'), '5')
-    await user.type(screen.getByPlaceholderText('Time (e.g. 45:30)'), '45:30')
-    await user.selectOptions(screen.getByRole('combobox'), 'Daily Trainer')
-    await user.click(screen.getByRole('button', { name: 'Log Run' }))
+  it("logs a run and derives mileage for the selected shoe", async () => {
+    render(<Harness />);
+    const user = await addShoe("Daily Trainer");
 
-    expect(
-      screen.getByText('5 mi in 45:30 wearing Daily Trainer')
-    ).toBeInTheDocument()
-    expect(screen.getByText('Daily Trainer: 5 mi')).toBeInTheDocument()
-  })
-})
+    await user.type(screen.getByPlaceholderText("Miles"), "5");
+    await user.type(screen.getByPlaceholderText("Time (e.g. 45:30)"), "45:30");
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Running shoes" }),
+      "shoe-1",
+    );
+    await user.click(screen.getByRole("button", { name: "Log Run" }));
+
+    expect(await screen.findByText(/5 mi in 45:30 wearing Daily Trainer/)).toBeInTheDocument();
+    expect(screen.getByText("Daily Trainer: 5 mi")).toBeInTheDocument();
+  });
+
+  it("edits and deletes a run without allowing shoe mileage to drift", async () => {
+    const shoe: Shoe = {
+      id: createShoeId("shoe-1"),
+      userId,
+      name: "Daily Trainer",
+      startingDistance: createDistanceMeters(0),
+      status: "active",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    const run: CompletedRun = {
+      id: createCompletedRunId("run-1"),
+      userId,
+      shoeId: shoe.id,
+      startedAt: timestamp,
+      timeZone: createIanaTimeZone("America/Los_Angeles"),
+      distance: createDistanceMeters(8_047),
+      duration: createDurationSeconds(2_400),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    const user = userEvent.setup();
+    render(<Harness initialShoes={[shoe]} initialRuns={[run]} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.clear(screen.getByRole("spinbutton", { name: "Edit miles" }));
+    await user.type(screen.getByRole("spinbutton", { name: "Edit miles" }), "3");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Daily Trainer: 3 mi")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(await screen.findByText("No runs logged yet.")).toBeInTheDocument();
+    expect(screen.getByText("Daily Trainer: 0 mi")).toBeInTheDocument();
+  });
+});

--- a/src/components/ShoeTracker.tsx
+++ b/src/components/ShoeTracker.tsx
@@ -1,95 +1,348 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import {
+  calculateShoeDistance,
+  createPlannedWorkoutId,
+  createShoeId,
+  createTrainingPlanId,
+  createDurationSeconds,
+  createIanaTimeZone,
+  createUtcDateTime,
+  getRunLocalDate,
+  metersToMiles,
+  milesToMeters,
+  type CompletedRun,
+  type CompletedRunId,
+  type DistanceMeters,
+  type PlannedWorkout,
+  type Shoe,
+} from "../domain/training";
+import type {
+  CreateCompletedRunInput,
+  CreateShoeInput,
+  UpdateCompletedRunInput,
+} from "../persistence/trainingRepositories";
 
-
-type Run = {
-  miles: number;
-  time: string;
-  shoe: string;
+type ShoeTrackerProps = {
+  readonly runs: readonly CompletedRun[];
+  readonly shoes: readonly Shoe[];
+  readonly plannedWorkouts: readonly PlannedWorkout[];
+  readonly onCreateShoe: (input: CreateShoeInput) => Promise<Shoe>;
+  readonly onCreateRun: (input: CreateCompletedRunInput) => Promise<CompletedRun>;
+  readonly onUpdateRun: (
+    id: CompletedRunId,
+    changes: UpdateCompletedRunInput,
+  ) => Promise<CompletedRun>;
+  readonly onDeleteRun: (id: CompletedRunId) => Promise<void>;
 };
 
-type Shoes = {
-  [key: string]: number;
-};
+function today(): string {
+  const value = new Date();
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
 
-export default function RunTracker() {
-  const [runs, setRuns] = useState<Run[]>([]);
-  const [shoes, setShoes] = useState<Shoes>({});
-  const [newShoe, setNewShoe] = useState<string>("");
+function currentTimeZone() {
+  const value = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  return createIanaTimeZone(value);
+}
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const miles = parseFloat(formData.get("miles") as string);
-    const time = formData.get("time") as string;
-    const shoe = formData.get("shoe") as string;
+function dateToUtc(date: string) {
+  return createUtcDateTime(new Date(`${date}T12:00:00`).toISOString());
+}
 
-    if (!miles || !time || !shoe) return;
+function parseDuration(value: string) {
+  const parts = value.split(":").map(Number);
+  const isValidPart = parts.every((part) => Number.isInteger(part) && part >= 0);
 
-    setRuns((prevRuns) => [...prevRuns, { miles, time, shoe }]);
+  if (!isValidPart || (parts.length !== 2 && parts.length !== 3)) {
+    throw new Error("Use MM:SS or H:MM:SS for elapsed time.");
+  }
 
-    setShoes((prevShoes) => ({
-      ...prevShoes,
-      [shoe]: (prevShoes[shoe] || 0) + miles,
-    }));
+  const [hours, minutes, seconds] =
+    parts.length === 3 ? parts : [0, parts[0], parts[1]];
 
-    e.currentTarget.reset();
+  if (seconds >= 60 || (parts.length === 3 && minutes >= 60)) {
+    throw new Error("Seconds, and minutes after an hour, must be less than 60.");
+  }
+
+  return createDurationSeconds(hours * 3600 + minutes * 60 + seconds);
+}
+
+function formatDuration(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = String(totalSeconds % 60).padStart(2, "0");
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, "0")}:${seconds}`
+    : `${minutes}:${seconds}`;
+}
+
+function formatMiles(meters: DistanceMeters): string {
+  return Number(metersToMiles(meters).toFixed(2)).toString();
+}
+
+function workoutName(workout: PlannedWorkout): string {
+  if (workout.kind === "walk_run") return "Walk/run";
+  if (workout.kind === "rest") return "Rest";
+  return `${workout.purpose[0].toUpperCase()}${workout.purpose.slice(1)} run`;
+}
+
+export default function ShoeTracker({
+  runs,
+  shoes,
+  plannedWorkouts,
+  onCreateShoe,
+  onCreateRun,
+  onUpdateRun,
+  onDeleteRun,
+}: ShoeTrackerProps) {
+  const [newShoe, setNewShoe] = useState("");
+  const [runDate, setRunDate] = useState(today);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [editingRunId, setEditingRunId] = useState<CompletedRunId | null>(null);
+  const activeShoes = shoes.filter((shoe) => shoe.status === "active");
+  const availableWorkouts = plannedWorkouts.filter(
+    (workout) => workout.kind !== "rest" && workout.status === "planned",
+  );
+  const shoeMileage = useMemo(
+    () =>
+      new Map(
+        shoes.map((shoe) => [shoe.id, calculateShoeDistance(shoe, runs)]),
+      ),
+    [runs, shoes],
+  );
+
+  const handleAddShoe = async () => {
+    const name = newShoe.trim();
+    if (name.length === 0) return;
+
+    setError(null);
+    setPending(true);
+    try {
+      await onCreateShoe({ name });
+      setNewShoe("");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "The shoe could not be saved.");
+    } finally {
+      setPending(false);
+    }
   };
 
-  const handleAddShoe = () => {
-    if (newShoe.trim() && !shoes[newShoe]) {
-      setShoes((prevShoes) => ({ ...prevShoes, [newShoe]: 0 }));
-      setNewShoe("");
+  const handleRunSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    setError(null);
+    setPending(true);
+    try {
+      const association = String(formData.get("workout") ?? "");
+      const [plannedWorkoutPlanId, plannedWorkoutId] = association
+        ? association.split("/")
+        : [];
+      await onCreateRun({
+        plannedWorkoutPlanId: plannedWorkoutPlanId
+          ? createTrainingPlanId(plannedWorkoutPlanId)
+          : undefined,
+        plannedWorkoutId: plannedWorkoutId
+          ? createPlannedWorkoutId(plannedWorkoutId)
+          : undefined,
+        shoeId: createShoeId(String(formData.get("shoe"))),
+        startedAt: dateToUtc(runDate),
+        timeZone: currentTimeZone(),
+        distance: milesToMeters(Number(formData.get("miles"))),
+        duration: parseDuration(String(formData.get("time"))),
+      });
+      form.reset();
+      setRunDate(today());
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "The run could not be saved.");
+    } finally {
+      setPending(false);
     }
   };
 
   return (
     <div className="tracker">
-      {/* Left Side: Run Entry Form */}
+      {error && <p role="alert" className="training-error">{error}</p>}
       <div className="entry">
         <h2>Run</h2>
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <input name="miles" type="number" step="0.1" placeholder="Miles" required />
+        {activeShoes.length === 0 && (
+          <p className="training-empty-state">
+            Add your current running shoes before logging a run.
+          </p>
+        )}
+        <form onSubmit={handleRunSubmit} className="space-y-3">
+          <input
+            aria-label="Run date"
+            name="date"
+            type="date"
+            value={runDate}
+            onChange={(event) => setRunDate(event.target.value)}
+            required
+          />
+          <input name="miles" type="number" min="0.01" step="0.01" placeholder="Miles" required />
           <input name="time" type="text" placeholder="Time (e.g. 45:30)" required />
-          <select name="shoe" required>
+          <select name="shoe" aria-label="Running shoes" required>
             <option value="">Select Shoes</option>
-            {Object.keys(shoes).map((shoe) => (
-              <option key={shoe} value={shoe}>
-                {shoe} ({shoes[shoe]} mi)
+            {activeShoes.map((shoe) => (
+              <option key={shoe.id} value={shoe.id}>
+                {shoe.name} ({formatMiles(shoeMileage.get(shoe.id) ?? shoe.startingDistance)} mi)
               </option>
             ))}
           </select>
-          <button type="submit">Log Run</button>
+          <select name="workout" aria-label="Planned workout">
+            <option value="">Unplanned run</option>
+            {availableWorkouts.map((workout) => (
+              <option
+                key={workout.id}
+                value={`${workout.planId}/${workout.id}`}
+              >
+                {workout.scheduledDate}: {workoutName(workout)}
+              </option>
+            ))}
+          </select>
+          <button type="submit" disabled={pending || activeShoes.length === 0}>
+            Log Run
+          </button>
         </form>
 
         <div className="mt-4">
           <h3 className="text-lg font-medium">Logged Runs</h3>
-          <ul>
-            {runs.map((run, index) => (
-              <li key={index}>
-                {run.miles} mi in {run.time} wearing {run.shoe}
-              </li>
-            ))}
-          </ul>
+          {runs.length === 0 ? (
+            <p className="training-empty-state">No runs logged yet.</p>
+          ) : (
+            <ul>
+              {runs.map((run) => {
+                const shoe = shoes.find((candidate) => candidate.id === run.shoeId);
+                const isEditing = editingRunId === run.id;
+
+                return (
+                  <li key={run.id}>
+                    {isEditing ? (
+                      <form
+                        aria-label={`Edit run from ${getRunLocalDate(run)}`}
+                        onSubmit={async (event) => {
+                          event.preventDefault();
+                          const data = new FormData(event.currentTarget);
+                          setError(null);
+                          setPending(true);
+                          try {
+                            await onUpdateRun(run.id, {
+                              distance: milesToMeters(Number(data.get("miles"))),
+                              duration: parseDuration(String(data.get("time"))),
+                              shoeId: createShoeId(String(data.get("shoe"))),
+                            });
+                            setEditingRunId(null);
+                          } catch (caught) {
+                            setError(caught instanceof Error ? caught.message : "The run could not be updated.");
+                          } finally {
+                            setPending(false);
+                          }
+                        }}
+                      >
+                        <input
+                          aria-label="Edit miles"
+                          name="miles"
+                          type="number"
+                          min="0.01"
+                          step="0.01"
+                          defaultValue={formatMiles(run.distance)}
+                          required
+                        />
+                        <input
+                          aria-label="Edit elapsed time"
+                          name="time"
+                          defaultValue={formatDuration(run.duration)}
+                          required
+                        />
+                        <select
+                          aria-label="Edit running shoes"
+                          name="shoe"
+                          defaultValue={run.shoeId}
+                          required
+                        >
+                          {shoes
+                            .filter(
+                              (candidate) =>
+                                candidate.status === "active" ||
+                                candidate.id === run.shoeId,
+                            )
+                            .map((candidate) => (
+                            <option key={candidate.id} value={candidate.id}>
+                              {candidate.name}
+                            </option>
+                            ))}
+                        </select>
+                        <button type="submit" disabled={pending}>Save</button>
+                        <button type="button" onClick={() => setEditingRunId(null)}>
+                          Cancel
+                        </button>
+                      </form>
+                    ) : (
+                      <>
+                        {getRunLocalDate(run)}: {formatMiles(run.distance)} mi in{" "}
+                        {formatDuration(run.duration)} wearing {shoe?.name ?? "No shoe"}
+                        <button type="button" onClick={() => setEditingRunId(run.id)}>
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          disabled={pending}
+                          onClick={async () => {
+                            setError(null);
+                            setPending(true);
+                            try {
+                              await onDeleteRun(run.id);
+                            } catch (caught) {
+                              setError(caught instanceof Error ? caught.message : "The run could not be deleted.");
+                            } finally {
+                              setPending(false);
+                            }
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </div>
       </div>
 
-      {/* Right Side: Shoe Management */}
       <div className="shoe-tracking">
         <h3 className="text-lg font-medium">Add New Shoes</h3>
         <div className="flex space-x-2 mt-2">
-          <input type="text" value={newShoe} onChange={(e) => setNewShoe(e.target.value)} placeholder="Shoe Name" />
-          <button onClick={handleAddShoe}>Add</button>
+          <input
+            type="text"
+            value={newShoe}
+            onChange={(event) => setNewShoe(event.target.value)}
+            placeholder="Shoe Name"
+          />
+          <button type="button" onClick={handleAddShoe} disabled={pending}>
+            Add
+          </button>
         </div>
 
         <div className="mt-4">
           <h3 className="text-lg font-medium">Shoe Mileage</h3>
-          <ul>
-            {Object.entries(shoes).map(([shoe, miles]) => (
-              <li key={shoe}>
-                {shoe}: {miles} mi
-              </li>
-            ))}
-          </ul>
+          {shoes.length === 0 ? (
+            <p className="training-empty-state">No shoes added yet.</p>
+          ) : (
+            <ul>
+              {shoes.map((shoe) => (
+                <li key={shoe.id}>
+                  {shoe.name}: {formatMiles(shoeMileage.get(shoe.id) ?? shoe.startingDistance)} mi
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       </div>
     </div>

--- a/src/domain/training/calculations.ts
+++ b/src/domain/training/calculations.ts
@@ -1,6 +1,22 @@
+import { createDateOnly, type DateOnly } from "./dates";
 import type { ShoeId, UserId } from "./identifiers";
 import type { CompletedRun, Shoe } from "./types";
-import { createDistanceMeters, type DistanceMeters } from "./units";
+import {
+  calculatePace,
+  createDistanceMeters,
+  createDurationSeconds,
+  type DistanceMeters,
+  type DistanceUnit,
+  type Pace,
+} from "./units";
+
+export interface TrainingAnalytics {
+  readonly totalDistance: DistanceMeters;
+  readonly weeklyDistance: DistanceMeters;
+  readonly averagePace: Pace | null;
+  readonly totalRuns: number;
+  readonly runsThisWeek: number;
+}
 
 export function calculateTotalDistance(runs: readonly CompletedRun[]): DistanceMeters {
   const total = runs.reduce((sum, run) => sum + run.distance, 0);
@@ -24,4 +40,46 @@ export function findRunsForShoe(
   shoeId: ShoeId,
 ): CompletedRun[] {
   return runs.filter((run) => run.userId === userId && run.shoeId === shoeId);
+}
+
+function addDays(date: DateOnly, numberOfDays: number): DateOnly {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + numberOfDays);
+  return createDateOnly(value.toISOString().slice(0, 10));
+}
+
+export function getRunLocalDate(run: CompletedRun): DateOnly {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: run.timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(run.startedAt));
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+
+  return createDateOnly(`${values.year}-${values.month}-${values.day}`);
+}
+
+export function calculateTrainingAnalytics(
+  runs: readonly CompletedRun[],
+  weekStart: DateOnly,
+  distanceUnit: DistanceUnit,
+): TrainingAnalytics {
+  const weekEnd = addDays(weekStart, 6);
+  const weeklyRuns = runs.filter((run) => {
+    const runDate = getRunLocalDate(run);
+    return runDate >= weekStart && runDate <= weekEnd;
+  });
+  const totalDistance = calculateTotalDistance(runs);
+  const totalDuration = createDurationSeconds(
+    runs.reduce((sum, run) => sum + run.duration, 0),
+  );
+
+  return {
+    totalDistance,
+    weeklyDistance: calculateTotalDistance(weeklyRuns),
+    averagePace: calculatePace(totalDistance, totalDuration, distanceUnit),
+    totalRuns: runs.length,
+    runsThisWeek: weeklyRuns.length,
+  };
 }

--- a/src/domain/training/training.test.ts
+++ b/src/domain/training/training.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   calculatePace,
   calculateShoeDistance,
+  calculateTrainingAnalytics,
   calculateTotalDistance,
   createCompletedRunId,
   createDateOnly,
@@ -232,5 +233,29 @@ describe("training domain calculations", () => {
     expect(calculateShoeDistance(shoe, [run, differentShoeRun, differentUserRun])).toBe(
       milesToMeters(15),
     );
+  });
+
+  it("derives weekly and lifetime analytics from completed runs", () => {
+    const nextWeekRun: CompletedRun = {
+      ...run,
+      id: createCompletedRunId("run-2"),
+      plannedWorkoutPlanId: undefined,
+      plannedWorkoutId: undefined,
+      startedAt: createUtcDateTime("2026-08-10T14:00:00Z"),
+      distance: milesToMeters(2),
+      duration: createDurationSeconds(20 * 60),
+    };
+
+    const analytics = calculateTrainingAnalytics(
+      [run, nextWeekRun],
+      createDateOnly("2026-08-03"),
+      "mile",
+    );
+
+    expect(analytics.totalDistance).toBe(milesToMeters(5));
+    expect(analytics.weeklyDistance).toBe(milesToMeters(3));
+    expect(analytics.totalRuns).toBe(2);
+    expect(analytics.runsThisWeek).toBe(1);
+    expect(analytics.averagePace?.secondsPerUnit).toBeCloseTo(600, 0);
   });
 });

--- a/src/training/TrainingDataContext.ts
+++ b/src/training/TrainingDataContext.ts
@@ -1,0 +1,36 @@
+import { createContext } from "react";
+import type {
+  CompletedRun,
+  CompletedRunId,
+  PlannedWorkout,
+  Shoe,
+  TrainingPlan,
+} from "../domain/training";
+import type {
+  CreateCompletedRunInput,
+  CreateShoeInput,
+  UpdateCompletedRunInput,
+} from "../persistence/trainingRepositories";
+
+export type TrainingDataStatus = "loading" | "ready" | "error";
+
+export interface TrainingDataContextValue {
+  readonly status: TrainingDataStatus;
+  readonly error: string | null;
+  readonly plans: TrainingPlan[];
+  readonly workouts: PlannedWorkout[];
+  readonly runs: CompletedRun[];
+  readonly shoes: Shoe[];
+  readonly reload: () => Promise<void>;
+  readonly createShoe: (input: CreateShoeInput) => Promise<Shoe>;
+  readonly createRun: (input: CreateCompletedRunInput) => Promise<CompletedRun>;
+  readonly updateRun: (
+    id: CompletedRunId,
+    changes: UpdateCompletedRunInput,
+  ) => Promise<CompletedRun>;
+  readonly deleteRun: (id: CompletedRunId) => Promise<void>;
+}
+
+export const TrainingDataContext = createContext<
+  TrainingDataContextValue | undefined
+>(undefined);

--- a/src/training/TrainingDataProvider.test.tsx
+++ b/src/training/TrainingDataProvider.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  calculateShoeDistance,
+  calculateTrainingAnalytics,
+  createDateOnly,
+  createDurationSeconds,
+  createIanaTimeZone,
+  createUserId,
+  createUtcDateTime,
+  metersToMiles,
+  milesToMeters,
+} from "../domain/training";
+import { createDocumentTrainingRepositories } from "../persistence/documentTrainingRepositories";
+import { InMemoryDocumentStore } from "../persistence/testing/InMemoryDocumentStore";
+import type { TrainingRepositories } from "../persistence/trainingRepositories";
+import TrainingDataProvider, {
+  type TrainingRepositoryFactory,
+} from "./TrainingDataProvider";
+import { useTrainingData } from "./useTrainingData";
+
+const userId = createUserId("runner-1");
+const timestamp = createUtcDateTime("2026-08-03T12:00:00Z");
+const timeZone = createIanaTimeZone("America/Los_Angeles");
+
+let repositories: TrainingRepositories;
+let repositoryFactory: TrainingRepositoryFactory;
+
+beforeEach(() => {
+  repositories = createDocumentTrainingRepositories(
+    new InMemoryDocumentStore(),
+    userId,
+    () => timestamp,
+  );
+  repositoryFactory = async () => repositories;
+});
+
+function IntegrationProbe() {
+  const training = useTrainingData();
+
+  if (training.status !== "ready") {
+    return <p>{training.error ? `${training.status}: ${training.error}` : training.status}</p>;
+  }
+
+  const workout = training.workouts[0];
+  const shoe = training.shoes[0];
+  const run = training.runs[0];
+  const analytics = calculateTrainingAnalytics(
+    training.runs,
+    createDateOnly("2026-08-03"),
+    "mile",
+  );
+  const shoeMiles = shoe
+    ? metersToMiles(calculateShoeDistance(shoe, training.runs))
+    : 0;
+
+  return (
+    <div>
+      <p>Runs: {training.runs.length}</p>
+      <p>Workout: {workout?.status ?? "none"}</p>
+      <p>Total: {Number(metersToMiles(analytics.totalDistance).toFixed(1))}</p>
+      <p>Shoe: {Number(shoeMiles.toFixed(1))}</p>
+      <button
+        type="button"
+        disabled={!workout || !shoe}
+        onClick={() =>
+          void training.createRun({
+            plannedWorkoutPlanId: workout.planId,
+            plannedWorkoutId: workout.id,
+            shoeId: shoe.id,
+            startedAt: createUtcDateTime("2026-08-03T14:00:00Z"),
+            timeZone,
+            distance: milesToMeters(3),
+            duration: createDurationSeconds(1_800),
+          })
+        }
+      >
+        Complete workout
+      </button>
+      <button
+        type="button"
+        disabled={!run}
+        onClick={() =>
+          run && void training.updateRun(run.id, { distance: milesToMeters(4) })
+        }
+      >
+        Edit run
+      </button>
+      <button
+        type="button"
+        disabled={!run}
+        onClick={() => run && void training.deleteRun(run.id)}
+      >
+        Delete run
+      </button>
+    </div>
+  );
+}
+
+describe("TrainingDataProvider", () => {
+  it("renders an empty authenticated training dataset", async () => {
+    render(
+      <TrainingDataProvider
+        userId={userId}
+        repositoryFactory={repositoryFactory}
+      >
+        <IntegrationProbe />
+      </TrainingDataProvider>,
+    );
+
+    expect(await screen.findByText("Runs: 0")).toBeInTheDocument();
+    expect(screen.getByText("Workout: none")).toBeInTheDocument();
+    expect(screen.getByText("Total: 0")).toBeInTheDocument();
+  });
+
+  it("keeps completion status, analytics, and shoe mileage in sync", async () => {
+    const plan = await repositories.plans.create({
+      name: "First Marathon Journey",
+      startDate: createDateOnly("2026-08-03"),
+      targetRaceDate: createDateOnly("2027-01-10"),
+    });
+    const plannedWorkout = await repositories.workouts.create({
+      planId: plan.id,
+      scheduledDate: createDateOnly("2026-08-03"),
+      phase: "base_building",
+      kind: "run",
+      purpose: "easy",
+      targetDistance: milesToMeters(5),
+    });
+    await repositories.shoes.create({ name: "Daily Trainer" });
+    const user = userEvent.setup();
+
+    render(
+      <TrainingDataProvider
+        userId={userId}
+        repositoryFactory={repositoryFactory}
+      >
+        <IntegrationProbe />
+      </TrainingDataProvider>,
+    );
+
+    await screen.findByText("Workout: planned");
+    await user.click(screen.getByRole("button", { name: "Complete workout" }));
+
+    expect(await screen.findByText("Runs: 1")).toBeInTheDocument();
+    expect(screen.getByText("Workout: completed")).toBeInTheDocument();
+    expect(screen.getByText("Total: 3")).toBeInTheDocument();
+    expect(screen.getByText("Shoe: 3")).toBeInTheDocument();
+    await expect(
+      repositories.workouts.get(plan.id, plannedWorkout.id),
+    ).resolves.toMatchObject({
+      status: "completed",
+      targetDistance: milesToMeters(5),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit run" }));
+    expect(await screen.findByText("Total: 4")).toBeInTheDocument();
+    expect(screen.getByText("Shoe: 4")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete run" }));
+    expect(await screen.findByText("Runs: 0")).toBeInTheDocument();
+    expect(screen.getByText("Workout: planned")).toBeInTheDocument();
+    expect(screen.getByText("Total: 0")).toBeInTheDocument();
+    expect(screen.getByText("Shoe: 0")).toBeInTheDocument();
+  });
+
+  it("surfaces a calm recoverable load error", async () => {
+    const failingFactory: TrainingRepositoryFactory = async () => {
+      throw new Error("Training data is temporarily unavailable.");
+    };
+
+    render(
+      <TrainingDataProvider userId={userId} repositoryFactory={failingFactory}>
+        <IntegrationProbe />
+      </TrainingDataProvider>,
+    );
+
+    expect(
+      await screen.findByText(
+        "error: Training data is temporarily unavailable.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/training/TrainingDataProvider.tsx
+++ b/src/training/TrainingDataProvider.tsx
@@ -1,0 +1,299 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  createUserId,
+  type CompletedRun,
+  type CompletedRunId,
+  type PlannedWorkout,
+  type Shoe,
+  type TrainingPlan,
+  type UserId,
+} from "../domain/training";
+import type {
+  CreateCompletedRunInput,
+  CreateShoeInput,
+  TrainingRepositories,
+  UpdateCompletedRunInput,
+} from "../persistence/trainingRepositories";
+import {
+  TrainingDataContext,
+  type TrainingDataContextValue,
+  type TrainingDataStatus,
+} from "./TrainingDataContext";
+
+export type TrainingRepositoryFactory = (
+  userId: UserId,
+) => Promise<TrainingRepositories>;
+
+type TrainingDataProviderProps = {
+  readonly userId: string;
+  readonly children: ReactNode;
+  readonly repositoryFactory?: TrainingRepositoryFactory;
+};
+
+interface TrainingSnapshot {
+  readonly status: TrainingDataStatus;
+  readonly error: string | null;
+  readonly plans: TrainingPlan[];
+  readonly workouts: PlannedWorkout[];
+  readonly runs: CompletedRun[];
+  readonly shoes: Shoe[];
+}
+
+const emptySnapshot: TrainingSnapshot = {
+  status: "loading",
+  error: null,
+  plans: [],
+  workouts: [],
+  runs: [],
+  shoes: [],
+};
+
+const defaultRepositoryFactory: TrainingRepositoryFactory = async (userId) => {
+  const { createFirestoreTrainingRepositories } = await import(
+    "../persistence/firestore"
+  );
+  return createFirestoreTrainingRepositories(userId);
+};
+
+function messageFor(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Your training data could not be loaded. Please try again.";
+}
+
+export default function TrainingDataProvider({
+  userId: rawUserId,
+  children,
+  repositoryFactory = defaultRepositoryFactory,
+}: TrainingDataProviderProps) {
+  const userId = useMemo(() => createUserId(rawUserId), [rawUserId]);
+  const repositoryRef = useRef<TrainingRepositories | null>(null);
+  const loadGenerationRef = useRef(0);
+  const [snapshot, setSnapshot] = useState<TrainingSnapshot>(emptySnapshot);
+
+  const load = useCallback(async () => {
+    const generation = loadGenerationRef.current + 1;
+    loadGenerationRef.current = generation;
+    setSnapshot((current) => ({ ...current, status: "loading", error: null }));
+
+    try {
+      const repositories = await repositoryFactory(userId);
+      const [plans, runs, shoes] = await Promise.all([
+        repositories.plans.list(),
+        repositories.runs.list(),
+        repositories.shoes.list(),
+      ]);
+      const workouts = (
+        await Promise.all(
+          plans.map((plan) => repositories.workouts.listForPlan(plan.id)),
+        )
+      ).flat();
+
+      if (generation !== loadGenerationRef.current) return;
+
+      repositoryRef.current = repositories;
+      setSnapshot({ status: "ready", error: null, plans, workouts, runs, shoes });
+    } catch (error) {
+      if (generation !== loadGenerationRef.current) return;
+
+      repositoryRef.current = null;
+      setSnapshot((current) => ({
+        ...current,
+        status: "error",
+        error: messageFor(error),
+      }));
+    }
+  }, [repositoryFactory, userId]);
+
+  useEffect(() => {
+    void load();
+
+    return () => {
+      loadGenerationRef.current += 1;
+      repositoryRef.current = null;
+    };
+  }, [load]);
+
+  const requireRepositories = useCallback(() => {
+    if (repositoryRef.current === null) {
+      throw new Error("Training data is still loading. Please try again.");
+    }
+
+    return repositoryRef.current;
+  }, []);
+
+  const createShoe = useCallback(
+    async (input: CreateShoeInput) => {
+      const shoe = await requireRepositories().shoes.create(input);
+      setSnapshot((current) => ({
+        ...current,
+        shoes: [...current.shoes, shoe].sort((left, right) =>
+          left.name.localeCompare(right.name),
+        ),
+      }));
+      return shoe;
+    },
+    [requireRepositories],
+  );
+
+  const createRun = useCallback(
+    async (input: CreateCompletedRunInput) => {
+      const repositories = requireRepositories();
+      const associatedWorkout =
+        input.plannedWorkoutPlanId === undefined ||
+        input.plannedWorkoutId === undefined
+          ? null
+          : snapshot.workouts.find(
+              (workout) =>
+                workout.planId === input.plannedWorkoutPlanId &&
+                workout.id === input.plannedWorkoutId,
+            ) ?? null;
+
+      if (associatedWorkout?.kind === "rest") {
+        throw new Error("A completed run cannot be attached to a rest day.");
+      }
+
+      if (
+        input.plannedWorkoutPlanId !== undefined &&
+        input.plannedWorkoutId !== undefined &&
+        associatedWorkout === null
+      ) {
+        throw new Error("That planned workout is no longer available.");
+      }
+
+      if (associatedWorkout?.status === "completed") {
+        throw new Error("That planned workout already has a completion record.");
+      }
+
+      const run = await repositories.runs.create(input);
+      let completedWorkout: PlannedWorkout | null = null;
+
+      if (
+        run.plannedWorkoutPlanId !== undefined &&
+        run.plannedWorkoutId !== undefined
+      ) {
+        try {
+          completedWorkout = await repositories.workouts.update(
+            run.plannedWorkoutPlanId,
+            run.plannedWorkoutId,
+            { status: "completed" },
+          );
+        } catch (error) {
+          await repositories.runs.delete(run.id);
+          throw error;
+        }
+      }
+
+      setSnapshot((current) => ({
+        ...current,
+        runs: [run, ...current.runs],
+        workouts:
+          completedWorkout === null
+            ? current.workouts
+            : current.workouts.map((workout) =>
+                workout.planId === completedWorkout.planId &&
+                workout.id === completedWorkout.id
+                  ? completedWorkout
+                  : workout,
+              ),
+      }));
+      return run;
+    },
+    [requireRepositories, snapshot.workouts],
+  );
+
+  const updateRun = useCallback(
+    async (id: CompletedRunId, changes: UpdateCompletedRunInput) => {
+      const updated = await requireRepositories().runs.update(id, changes);
+      setSnapshot((current) => ({
+        ...current,
+        runs: current.runs
+          .map((run) => (run.id === updated.id ? updated : run))
+          .sort((left, right) => right.startedAt.localeCompare(left.startedAt)),
+      }));
+      return updated;
+    },
+    [requireRepositories],
+  );
+
+  const deleteRun = useCallback(
+    async (id: CompletedRunId) => {
+      const repositories = requireRepositories();
+      const run = snapshot.runs.find((candidate) => candidate.id === id);
+
+      if (run === undefined) {
+        return;
+      }
+
+      const hasAnotherCompletion = snapshot.runs.some(
+        (candidate) =>
+          candidate.id !== run.id &&
+          candidate.plannedWorkoutPlanId === run.plannedWorkoutPlanId &&
+          candidate.plannedWorkoutId === run.plannedWorkoutId,
+      );
+      let reopenedWorkout: PlannedWorkout | null = null;
+
+      if (
+        !hasAnotherCompletion &&
+        run.plannedWorkoutPlanId !== undefined &&
+        run.plannedWorkoutId !== undefined
+      ) {
+        reopenedWorkout = await repositories.workouts.update(
+          run.plannedWorkoutPlanId,
+          run.plannedWorkoutId,
+          { status: "planned" },
+        );
+      }
+
+      try {
+        await repositories.runs.delete(id);
+      } catch (error) {
+        if (reopenedWorkout !== null) {
+          await repositories.workouts.update(
+            reopenedWorkout.planId,
+            reopenedWorkout.id,
+            { status: "completed" },
+          );
+        }
+        throw error;
+      }
+
+      setSnapshot((current) => ({
+        ...current,
+        runs: current.runs.filter((candidate) => candidate.id !== id),
+        workouts:
+          reopenedWorkout === null
+            ? current.workouts
+            : current.workouts.map((workout) =>
+                workout.planId === reopenedWorkout.planId &&
+                workout.id === reopenedWorkout.id
+                  ? reopenedWorkout
+                  : workout,
+              ),
+      }));
+    },
+    [requireRepositories, snapshot.runs],
+  );
+
+  const value: TrainingDataContextValue = {
+    ...snapshot,
+    reload: load,
+    createShoe,
+    createRun,
+    updateRun,
+    deleteRun,
+  };
+
+  return (
+    <TrainingDataContext.Provider value={value}>
+      {children}
+    </TrainingDataContext.Provider>
+  );
+}

--- a/src/training/useTrainingData.ts
+++ b/src/training/useTrainingData.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { TrainingDataContext } from "./TrainingDataContext";
+
+export function useTrainingData() {
+  const value = useContext(TrainingDataContext);
+
+  if (value === undefined) {
+    throw new Error("useTrainingData must be used within TrainingDataProvider.");
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary

- Load plans, workouts, completed runs, and shoes into one authenticated training-data state.
- Render Plan from persisted workouts and replace demo values in Analyze with derived mileage, pace, and run counts.
- Persist shoe creation plus run logging, editing, deletion, and optional planned-workout completion.
- Recalculate analytics and shoe mileage from completed-run history so edits and deletions cannot create drift.
- Document empty states, partial workouts, unplanned runs, rest days, weekly boundaries, and deletion behavior.

## Linked issue

Closes #13

## Verification

- [x] `npm run lint`
- [x] `npm test` (60 tests passed)
- [x] `npm run test:firestore` (7 emulator tests passed)
- [x] `npm run build`
- [x] `npm audit --omit=dev` (0 vulnerabilities)
- [x] Verified signed-out browser behavior remains intact
- [x] Deployed the tested Firestore rules and indexes to `marathoner-d9bf9`
- [x] Verified authenticated production reads and empty states in Plan, Track, and Analyze
- [x] Maintainer reviewed every changed line

## Production verification scope

The authenticated account currently has no plans, workouts, runs, or shoes. Production verification confirmed that all three features read successfully from Firestore and render honest empty states. No production write smoke test was performed because creating a shoe would leave persistent test data and shoe deletion is not part of this issue. Repository and emulator tests cover shoe creation, run creation, planned-workout association, editing, deletion, ownership, and derived recalculation.

## Notes

Accounts without a persisted plan now receive an honest empty state. Personalized plan creation remains in issue #29. Training records reload on a new session or page refresh; real-time cross-device listeners remain future work. The product rules and calculation definitions are documented in `docs/architecture/training-feature-integration.md`.