### PR TITLE
fix: make workout dialog keyboard accessible

### DIFF
--- a/src/components/Calendar.test.tsx
+++ b/src/components/Calendar.test.tsx
@@ -89,14 +89,29 @@ describe("Calendar", () => {
 
   it("opens and closes a persisted workout detail", async () => {
     const user = userEvent.setup();
-    render(<Calendar plan={plan} workouts={workouts} />);
+    const { getByRole } = render(<Calendar plan={plan} workouts={workouts} />);
 
-    await user.click(screen.getByRole("button", { name: "2026-08-03: Easy run" }));
+    const trigger = getByRole("button", { name: "2026-08-03: Easy run" });
+    await user.click(trigger);
     expect(
       screen.getByRole("heading", { name: "2026-08-03 Details" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
 
     await user.click(screen.getByRole("button", { name: "Close" }));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("dismisses the detail with Escape and restores focus", async () => {
+    const user = userEvent.setup();
+    render(<Calendar plan={plan} workouts={workouts} />);
+
+    const trigger = screen.getByRole("button", { name: "2026-08-03: Easy run" });
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
   });
 });

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   metersToMiles,
   type PlannedWorkout,
@@ -57,11 +57,52 @@ export default function Calendar({ plan, workouts }: CalendarProps) {
   const [selectedWorkout, setSelectedWorkout] =
     useState<PlannedWorkout | null>(null);
   const [selectedWeek, setSelectedWeek] = useState(1);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     setSelectedWeek(1);
     setSelectedWorkout(null);
   }, [plan?.id]);
+
+  useEffect(() => {
+    if (!selectedWorkout) return undefined;
+
+    const dialog = dialogRef.current;
+    const focusable = dialog
+      ? Array.from(
+          dialog.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          ),
+        )
+      : [];
+    focusable[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSelectedWorkout(null);
+        return;
+      }
+      if (event.key !== "Tab" || focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      triggerRef.current?.focus();
+    };
+  }, [selectedWorkout]);
 
   const weekCount = useMemo(() => {
     if (plan === null) return 0;
@@ -126,7 +167,10 @@ export default function Calendar({ plan, workouts }: CalendarProps) {
               key={workout.id}
               type="button"
               className={`plan-day ${workoutColorClass(workout)} ${workout.status}`}
-              onClick={() => setSelectedWorkout(workout)}
+              onClick={(event) => {
+                triggerRef.current = event.currentTarget;
+                setSelectedWorkout(workout);
+              }}
               aria-label={`${workout.scheduledDate}: ${workoutLabel(workout)}`}
             >
               <span className="plan-day-number">{workout.scheduledDate.slice(5)}</span>
@@ -148,6 +192,7 @@ export default function Calendar({ plan, workouts }: CalendarProps) {
             role="dialog"
             aria-modal="true"
             aria-labelledby="workout-detail-title"
+            ref={dialogRef}
             onClick={(event) => event.stopPropagation()}
           >
             <h3 id="workout-detail-title">


### PR DESCRIPTION
Fixes #64\n\n## Summary\n- focus the first dialog control when workout details open\n- dismiss the dialog with Escape and keep Tab focus contained\n- restore focus to the workout trigger after Escape or Close\n- cover the keyboard contract through accessible roles and names\n\n## Validation\n- 
pm test (61 tests)\n- 
pm run build\n- 
pm run lint\n- git diff --check\n\nThe implementation stays limited to the existing workout detail dialog.